### PR TITLE
fix: prevent stack overflow from separator recursion in Get/GetE

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -285,7 +285,11 @@ func GetE(value interface{}, path string) (Result, error) {
 				}
 				return result, nil
 			default:
-				return GetE(result.raw, path[index+1:])
+				value = result.raw
+				tp = reflect.TypeOf(value)
+				tv = reflect.ValueOf(value)
+				path = path[index+1:]
+				index = -1
 			}
 		case '#':
 			// 转化成slice 类型 平铺
@@ -413,7 +417,11 @@ func Get(value interface{}, path string) Result {
 				result.raw = list[ln:]
 				return result
 			default:
-				return Get(result.raw, path[index+1:])
+				value = result.raw
+				tp = reflect.TypeOf(value)
+				tv = reflect.ValueOf(value)
+				path = path[index+1:]
+				index = -1
 			}
 		case '#':
 			// 转化成slice 类型 平铺


### PR DESCRIPTION
## Summary
- Convert recursive `return Get/GetE(result.raw, path[index+1:])` in separator handling to iterative processing
- Crafted paths like `strings.Repeat(".", 1_000_000)` previously caused unrecoverable `fatal error: stack overflow`
- Fix resets value/tp/tv/path/index variables to continue the existing loop instead of recursing

## Test plan
- [x] All existing tests pass
- [x] Stack overflow test with 1M dots no longer crashes