### PR TITLE
fix: use current result for '#' deployment instead of root object

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -310,7 +310,7 @@ func GetE(value interface{}, path string) (Result, error) {
 			default:
 				result.deployment = true
 				var err error
-				result.raw, result.typ, err = deployment(tp, tv)
+				result.raw, result.typ, err = deployment(reflect.TypeOf(result.raw), reflect.ValueOf(result.raw))
 				if err != nil {
 					return result, warpError(err, value, "#")
 				}
@@ -435,7 +435,7 @@ func Get(value interface{}, path string) Result {
 			default:
 				result.deployment = true
 				var err error
-				result.raw, result.typ, err = deployment(tp, tv)
+				result.raw, result.typ, err = deployment(reflect.TypeOf(result.raw), reflect.ValueOf(result.raw))
 				if err != nil {
 					result.diagnosis = append(result.diagnosis, warpError(err, value, "#"))
 				}

--- a/ognl_test.go
+++ b/ognl_test.go
@@ -97,7 +97,7 @@ func TestGet(t *testing.T) {
 
 		{"#", []interface{}{"t1", 1, hash1, hash2, list, array, "lt1", 11, hash1, hash2, list, array}, true},
 		{"#string1#", []interface{}{"string", "string"}, true},
-		{"List#1.Name", []interface{}{"t3", "t3", "t3", "t3"}, true},
+		{"List#.Name", []interface{}{"t2", "t3", "t4"}, true},
 	}
 	for index, v := range test {
 		vv := Get(t1, v.query)


### PR DESCRIPTION
## Summary
- The `#` operator used the root object's `tp`/`tv` for deployment instead of `result.raw`
- Paths like `"users#"` incorrectly expanded the root object rather than the resolved field
- Fix: derive type/value from `reflect.TypeOf(result.raw)` / `reflect.ValueOf(result.raw)`
- Updated test case `"List#1.Name"` → `"List#.Name"` to reflect correct semantics

## Test plan
- [x] `TestP0_3_StaleTpTv` now returns len=2 (correct) instead of len=1 (bug)
- [x] `TestGet` passes with updated expectation
- [x] All other existing tests pass