### PR TITLE
fix: remove nil error append to diagnosis in GetE

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -314,7 +314,6 @@ func GetE(value interface{}, path string) (Result, error) {
 				if err != nil {
 					return result, warpError(err, value, "#")
 				}
-				result.diagnosis = append(result.diagnosis, err)
 			}
 
 		default:


### PR DESCRIPTION
## Summary
- GetE appended `err` to `result.diagnosis` unconditionally after the `if err != nil` return
- Since `err` is always nil at that point, `Diagnosis()` contained nil entries
- Fix: remove the spurious append line

## Test plan
- [x] `TestP1_2_NilErrInDiagnosis` — diagnosis is now empty
- [x] All existing tests pass