### PR TITLE
chore: remove unused min function

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -749,9 +749,3 @@ func warpError(err error, object interface{}, path string) error {
 	return fmt.Errorf("object:%v,path:%s,err: %w", object, path, err)
 }
 
-func min(a, b int) int {
-	if a > b {
-		return b
-	}
-	return a
-}


### PR DESCRIPTION
## Summary
- Remove dead code: `min` function (line 752-757) has no call sites
- Go 1.21+ provides a builtin `min`, making this doubly unnecessary

## Test plan
- [x] `go build ./...` succeeds
- [x] All existing tests pass