### PR TITLE
fix: prevent GetE expansion failures from succeeding (#25)

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -462,14 +462,14 @@ func getE(value interface{}, path string, depth int) (Result, error) {
 				} else {
 					nv, tpe, err = parseString(tp, tv, sv, 0)
 				}
+				result.raw = nv
+				result.typ = tpe
 				if err != nil {
 					return result, wrapError(err, value, sv)
 				}
 				if tpe == Invalid {
 					return result, wrapError(ErrInvalidValue, value, sv)
 				}
-				result.raw = nv
-				result.typ = tpe
 			}
 		}
 	}

--- a/verify_test.go
+++ b/verify_test.go
@@ -246,6 +246,71 @@ func TestGetE_ScalarHash_NoPanic(t *testing.T) {
 	})
 }
 
+// Issue #25: a failed non-expanded lookup retained the input value and its
+// initial Interface type, making the failed Result look successful.
+type issue25User struct {
+	Name string
+}
+
+func TestIssue25_GetEFailureIsInvalid(t *testing.T) {
+	r, err := GetE(issue25User{Name: "a"}, "Missing")
+	require.Error(t, err)
+	assert.Equal(t, Invalid, r.Type())
+	assert.False(t, r.Effective())
+	assert.Nil(t, r.Value())
+}
+
+func TestIssue25_GetEExpansionAllFailures(t *testing.T) {
+	users := []issue25User{{Name: "a"}}
+
+	t.Run("top-level", func(t *testing.T) {
+		r, err := GetE(users, "#.Missing")
+		require.Error(t, err)
+		assert.False(t, r.Effective())
+		assert.Empty(t, r.Values())
+		require.NotEmpty(t, r.Diagnosis())
+		assert.True(t, errors.Is(r.Diagnosis()[0], ErrInvalidValue))
+	})
+
+	t.Run("expanded Result", func(t *testing.T) {
+		expanded, err := GetE(users, "#")
+		require.NoError(t, err)
+
+		r, err := expanded.GetE("Missing")
+		require.Error(t, err)
+		assert.False(t, r.Effective())
+		assert.Empty(t, r.Values())
+		require.NotEmpty(t, r.Diagnosis())
+		assert.True(t, errors.Is(r.Diagnosis()[0], ErrInvalidValue))
+	})
+}
+
+func TestIssue25_GetEExpansionKeepsOnlySuccesses(t *testing.T) {
+	values := []interface{}{
+		issue25User{Name: "a"},
+		map[string]interface{}{"Missing": "found"},
+	}
+
+	t.Run("top-level", func(t *testing.T) {
+		r, err := GetE(values, "#.Missing")
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"found"}, r.Values())
+		require.Len(t, r.Diagnosis(), 1)
+		assert.True(t, errors.Is(r.Diagnosis()[0], ErrInvalidValue))
+	})
+
+	t.Run("expanded Result", func(t *testing.T) {
+		expanded, err := GetE(values, "#")
+		require.NoError(t, err)
+
+		r, err := expanded.GetE("Missing")
+		require.NoError(t, err)
+		assert.Equal(t, []interface{}{"found"}, r.Values())
+		require.Len(t, r.Diagnosis(), 1)
+		assert.True(t, errors.Is(r.Diagnosis()[0], ErrInvalidValue))
+	})
+}
+
 // ---- Coverage for previously-untested public API ----
 
 func TestCoverage_GetMany(t *testing.T) {

--- a/verify_test.go
+++ b/verify_test.go
@@ -260,6 +260,15 @@ func TestIssue25_GetEFailureIsInvalid(t *testing.T) {
 	assert.Nil(t, r.Value())
 }
 
+func TestIssue25_GetENonNilErrorFailureIsInvalid(t *testing.T) {
+	r, err := GetE(42, "Missing")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ErrInvalidStructure))
+	assert.Equal(t, Invalid, r.Type())
+	assert.False(t, r.Effective())
+	assert.Nil(t, r.Value())
+}
+
 func TestIssue25_GetEExpansionAllFailures(t *testing.T) {
 	users := []issue25User{{Name: "a"}}
 


### PR DESCRIPTION
## What

- invalidate failed non-expanded `GetE` lookups instead of retaining the original value
- cover top-level and expanded `Result.GetE` behavior for all-failure and partial-success expansions

## Why

A failed child lookup kept the initial `Interface` type and raw input. Expansion then treated that failed result as a successful match, returning original elements and sometimes a nil error.

Fixes #25

## How

Write the parser's `raw` and `typ` result back before checking its error or `Invalid` status. Failed children therefore remain invalid and expansion collects only successful values while preserving failures in `Diagnosis`.

## Tests

- red test confirmed the pre-fix direct, all-failure, and partial-success regressions
- mutation check restored the old write order and the issue tests failed again
- `test -z "$(gofmt -l .)" && git diff --check`
- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
