### PR TITLE
fix: handle nil embedded promoted fields (#26)

### DIFF
--- a/issue26_test.go
+++ b/issue26_test.go
@@ -1,0 +1,120 @@
+package ognl
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type issue26Inner struct {
+	A int
+}
+
+type issue26Outer struct {
+	*issue26Inner
+}
+
+type issue26Middle struct {
+	*issue26Inner
+}
+
+type issue26MultiOuter struct {
+	*issue26Middle
+}
+
+type issue26PrivateInner struct {
+	A int
+}
+
+type issue26PrivateOuter struct {
+	*issue26PrivateInner
+}
+
+func TestIssue26NilEmbeddedPointerPromotedField(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{
+			name:  "single level",
+			value: issue26Outer{},
+		},
+		{
+			name: "multiple levels",
+			value: issue26MultiOuter{
+				issue26Middle: &issue26Middle{},
+			},
+		},
+		{
+			name:  "private embedded type",
+			value: issue26PrivateOuter{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+" Get", func(t *testing.T) {
+			var result Result
+			require.NotPanics(t, func() {
+				result = Get(tt.value, "A")
+			})
+
+			assert.False(t, result.Effective())
+			require.NotEmpty(t, result.Diagnosis())
+			assert.True(t, errors.Is(result.Diagnosis()[0], ErrInvalidValue))
+		})
+
+		t.Run(tt.name+" GetE", func(t *testing.T) {
+			var err error
+			require.NotPanics(t, func() {
+				_, err = GetE(tt.value, "A")
+			})
+
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ErrInvalidValue))
+		})
+	}
+}
+
+func TestIssue26NonNilEmbeddedPointerPromotedField(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+		want  int
+	}{
+		{
+			name: "single level",
+			value: issue26Outer{
+				issue26Inner: &issue26Inner{A: 11},
+			},
+			want: 11,
+		},
+		{
+			name: "multiple levels",
+			value: issue26MultiOuter{
+				issue26Middle: &issue26Middle{
+					issue26Inner: &issue26Inner{A: 22},
+				},
+			},
+			want: 22,
+		},
+		{
+			name: "private embedded type",
+			value: issue26PrivateOuter{
+				issue26PrivateInner: &issue26PrivateInner{A: 33},
+			},
+			want: 33,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, Get(tt.value, "A").Value())
+
+			result, err := GetE(tt.value, "A")
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, result.Value())
+		})
+	}
+}

--- a/ognl.go
+++ b/ognl.go
@@ -723,18 +723,19 @@ func parseString(t reflect.Type, v reflect.Value, value string, depth int) (inte
 		return nil, Invalid, ErrSliceSubscript
 
 	case reflect.Struct:
-		rv := v.FieldByName(value)
-		if !rv.IsValid() {
+		rt, ok := t.FieldByName(value)
+		if !ok {
 			return nil, Invalid, nil
 		}
 
 		cp := reflect.New(v.Type()).Elem()
 		cp.Set(v)
-		rv = cp.FieldByName(value)
+		rv, err := cp.FieldByIndexErr(rt.Index)
+		if err != nil {
+			return nil, Invalid, ErrInvalidValue
+		}
 
 		res := reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem().Interface()
-
-		rt, _ := t.FieldByName(value)
 
 		if rt.Anonymous {
 			nv, nt, ne := parseString(reflect.TypeOf(res), reflect.ValueOf(res), value, depth+1)


### PR DESCRIPTION
## What

- Prevent promoted-field lookup through nil anonymous embedded pointers from panicking.
- Return an ineffective result with ErrInvalidValue diagnostics from Get, and an errors.Is-compatible ErrInvalidValue from GetE.
- Preserve promoted-field lookup for non-nil embedded pointers.

## Why

reflect.FieldByName can panic while traversing a nil embedded pointer before the previous validity check runs. This makes ordinary lookups capable of crashing the caller.

## How

Resolve the field metadata first, copy the struct into an addressable value, and use FieldByIndexErr so nil embedded-pointer traversal becomes an explicit error path. Keep the existing unsafe access only after a valid field value is obtained.

## Tests

- Adds regression coverage for Get and GetE without panics across single-level, multi-level, and private embedded pointer cases.
- Verifies errors.Is compatibility and ineffective-result diagnostics.
- Adds non-nil controls for all three shapes to lock existing promoted-field behavior.

Fixes #26