### PR TITLE
fix: bound # expansion resources (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ func main() {
 
 ## 错误处理
 
-- `Get` 不返回 error:无法解析时 `Result.Effective()` 返回 `false`,过程中的非致命错误记录在 `Result.Diagnosis()` 中。路径长度受限,对抗性路径不会耗尽调用栈。
+- `Get` 不返回 error:无法解析时 `Result.Effective()` 返回 `false`,过程中的非致命错误记录在 `Result.Diagnosis()` 中。递归下钻深度受限,对抗性路径不会耗尽调用栈。
 - `GetE` 返回首个致命错误。
+- 每次 `Get`/`GetE`（包括 `Result` 上的同名方法）的 `#` 展开最多执行 100,000 次操作并保留 10,000 个结果。超限时 `Get` 返回无效结果并在 `Diagnosis()` 中记录 `ErrExpansionLimit`，`GetE` 返回可由 `errors.Is` 识别的 `ErrExpansionLimit`，且不返回部分展开结果。
 - 所有错误都用 `%w` 包装,可用 `errors.Is(err, ognl.ErrInvalidValue)` 等判断;错误信息**只包含被遍历对象的类型名,不含其值**,避免泄露密码 / token 等敏感数据。
 
 ## API

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ func main() {
 
 - `Get` 不返回 error:无法解析时 `Result.Effective()` 返回 `false`,过程中的非致命错误记录在 `Result.Diagnosis()` 中。递归下钻深度受限,对抗性路径不会耗尽调用栈。
 - `GetE` 返回首个致命错误。
-- 每次 `Get`/`GetE`（包括 `Result` 上的同名方法）的 `#` 展开最多执行 100,000 次操作并保留 10,000 个结果。超限时 `Get` 返回无效结果并在 `Diagnosis()` 中记录 `ErrExpansionLimit`，`GetE` 返回可由 `errors.Is` 识别的 `ErrExpansionLimit`，且不返回部分展开结果。
+- 每次 `Get`/`GetE`（包括 `Result` 上的同名方法）的 `#` 展开最多执行 100,000 次操作，并在整个返回结果树中累计保留 10,000 个结果。超限时 `Get` 返回无效结果并在 `Diagnosis()` 中记录 `ErrExpansionLimit`，`GetE` 返回可由 `errors.Is` 识别的 `ErrExpansionLimit`，且不返回部分展开结果。
 - 所有错误都用 `%w` 包装,可用 `errors.Is(err, ognl.ErrInvalidValue)` 等判断;错误信息**只包含被遍历对象的类型名,不含其值**,避免泄露密码 / token 等敏感数据。
 
 ## API

--- a/issue_27_test.go
+++ b/issue_27_test.go
@@ -1,0 +1,166 @@
+package ognl
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type issue27Node struct {
+	Left  *issue27Node
+	Right *issue27Node
+}
+
+func issue27CyclicNode() *issue27Node {
+	root := &issue27Node{}
+	root.Left = root
+	root.Right = root
+	return root
+}
+
+func requireExpansionLimitDiagnosis(t *testing.T, result Result) {
+	t.Helper()
+	require.False(t, result.Effective())
+	require.Empty(t, result.Values(), "an expansion-limit failure must not expose partial output")
+	require.NotEmpty(t, result.Diagnosis())
+	assert.True(t, errors.Is(result.Diagnosis()[len(result.Diagnosis())-1], ErrExpansionLimit))
+}
+
+func assertNoExpansionLimitDiagnosis(t *testing.T, result Result) {
+	t.Helper()
+	for _, diagnosis := range result.Diagnosis() {
+		assert.False(t, errors.Is(diagnosis, ErrExpansionLimit), "unexpected expansion-limit diagnosis: %v", diagnosis)
+	}
+}
+
+func TestIssue27_ExpansionBudgetBoundsExponentialHash(t *testing.T) {
+	root := issue27CyclicNode()
+
+	// Twelve binary expansions are deliberately below the fixed output limit
+	// and lock the existing successful expansion behavior.
+	normalPath := strings.Repeat("#", 12)
+	normal := Get(root, normalPath)
+	require.True(t, normal.Effective())
+	require.Len(t, normal.Values(), 1<<12)
+	assertNoExpansionLimitDiagnosis(t, normal)
+
+	normalE, err := GetE(root, normalPath)
+	require.NoError(t, err)
+	require.Len(t, normalE.Values(), 1<<12)
+
+	// The issue's 18-level reproducer previously allocated and returned 262144
+	// elements. It must now fail closed before the result crosses the cap.
+	overPath := strings.Repeat("#", 18)
+	requireExpansionLimitDiagnosis(t, Get(root, overPath))
+
+	overE, err := GetE(root, overPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, overE.Effective())
+	assert.Empty(t, overE.Values())
+}
+
+func TestIssue27_ExpansionOutputBoundary(t *testing.T) {
+	exactInput := make([]int, maxExpansionResults)
+	exact := Get(exactInput, "#")
+	require.True(t, exact.Effective())
+	require.Len(t, exact.Values(), maxExpansionResults)
+	assertNoExpansionLimitDiagnosis(t, exact)
+
+	exactE, err := GetE(exactInput, "#")
+	require.NoError(t, err)
+	require.Len(t, exactE.Values(), maxExpansionResults)
+
+	overInput := make([]int, maxExpansionResults+1)
+	requireExpansionLimitDiagnosis(t, Get(overInput, "#"))
+
+	overE, err := GetE(overInput, "#")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, overE.Effective())
+	assert.Empty(t, overE.Values())
+}
+
+func TestIssue27_AggregateOutputLimitDiscardsPartialResult(t *testing.T) {
+	chunkSize := maxExpansionResults/2 + 1
+	input := []interface{}{make([]int, chunkSize), make([]int, chunkSize)}
+
+	requireExpansionLimitDiagnosis(t, Get(input, "##"))
+
+	result, err := GetE(input, "##")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, result.Effective())
+	assert.Empty(t, result.Values())
+}
+
+func TestIssue27_ExpansionOperationBoundary(t *testing.T) {
+	// A one-element cycle keeps the output size fixed while every '#' consumes
+	// one operator operation and scans one element. This isolates the operation
+	// budget from the output budget.
+	cycle := make([]interface{}, 1)
+	cycle[0] = cycle
+	exactPath := strings.Repeat("#", maxExpansionOperations/2)
+	exact := Get(cycle, exactPath)
+	require.True(t, exact.Effective())
+	require.Len(t, exact.Values(), 1)
+	assertNoExpansionLimitDiagnosis(t, exact)
+
+	exactE, err := GetE(cycle, exactPath)
+	require.NoError(t, err)
+	require.True(t, exactE.Effective())
+	require.Len(t, exactE.Values(), 1)
+
+	overPath := exactPath + "#"
+	requireExpansionLimitDiagnosis(t, Get(cycle, overPath))
+
+	overE, err := GetE(cycle, overPath)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, overE.Effective())
+	assert.Empty(t, overE.Values())
+}
+
+func TestIssue27_EmptyAndPartialExpansionRemainCompatible(t *testing.T) {
+	empty := Get([]int{}, "#")
+	assert.False(t, empty.Effective())
+	assertNoExpansionLimitDiagnosis(t, empty)
+
+	emptyE, err := GetE([]int{}, "#")
+	require.NoError(t, err)
+	assert.False(t, emptyE.Effective())
+
+	input := []interface{}{[]int{1, 2}, 42}
+	partial := Get(input, "##")
+	require.Equal(t, []interface{}{1, 2, 42}, partial.Values())
+	require.NotEmpty(t, partial.Diagnosis())
+	assert.ErrorIs(t, partial.Diagnosis()[0], ErrUnableExpand)
+	assertNoExpansionLimitDiagnosis(t, partial)
+
+	partialE, err := GetE(input, "##")
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{1, 2, 42}, partialE.Values())
+	require.NotEmpty(t, partialE.Diagnosis())
+	assert.ErrorIs(t, partialE.Diagnosis()[0], ErrUnableExpand)
+}
+
+func TestIssue27_ResultMethodsShareOneCallBudget(t *testing.T) {
+	cycle := make([]interface{}, 1)
+	cycle[0] = cycle
+	base := Get([]interface{}{cycle, cycle}, "#")
+	require.True(t, base.Effective())
+
+	// Each item alone stays below the operation limit. Sharing one budget across
+	// both items is what makes the Result.Get/Result.GetE call exceed the cap.
+	path := strings.Repeat("#", maxExpansionOperations/4+1)
+	requireExpansionLimitDiagnosis(t, base.Get(path))
+
+	result, err := base.GetE(path)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, result.Effective())
+	assert.Empty(t, result.Values())
+}

--- a/issue_27_test.go
+++ b/issue_27_test.go
@@ -9,6 +9,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// These literals intentionally duplicate the documented contract instead of
+// referencing production constants, so implementation drift makes tests fail.
+const (
+	issue27MaxExpansionOperations = 100_000
+	issue27MaxExpansionResults    = 10_000
+)
+
 type issue27Node struct {
 	Left  *issue27Node
 	Right *issue27Node
@@ -64,17 +71,17 @@ func TestIssue27_ExpansionBudgetBoundsExponentialHash(t *testing.T) {
 }
 
 func TestIssue27_ExpansionOutputBoundary(t *testing.T) {
-	exactInput := make([]int, maxExpansionResults)
+	exactInput := make([]int, issue27MaxExpansionResults)
 	exact := Get(exactInput, "#")
 	require.True(t, exact.Effective())
-	require.Len(t, exact.Values(), maxExpansionResults)
+	require.Len(t, exact.Values(), issue27MaxExpansionResults)
 	assertNoExpansionLimitDiagnosis(t, exact)
 
 	exactE, err := GetE(exactInput, "#")
 	require.NoError(t, err)
-	require.Len(t, exactE.Values(), maxExpansionResults)
+	require.Len(t, exactE.Values(), issue27MaxExpansionResults)
 
-	overInput := make([]int, maxExpansionResults+1)
+	overInput := make([]int, issue27MaxExpansionResults+1)
 	requireExpansionLimitDiagnosis(t, Get(overInput, "#"))
 
 	overE, err := GetE(overInput, "#")
@@ -85,7 +92,7 @@ func TestIssue27_ExpansionOutputBoundary(t *testing.T) {
 }
 
 func TestIssue27_AggregateOutputLimitDiscardsPartialResult(t *testing.T) {
-	chunkSize := maxExpansionResults/2 + 1
+	chunkSize := issue27MaxExpansionResults/2 + 1
 	input := []interface{}{make([]int, chunkSize), make([]int, chunkSize)}
 
 	requireExpansionLimitDiagnosis(t, Get(input, "##"))
@@ -103,7 +110,7 @@ func TestIssue27_ExpansionOperationBoundary(t *testing.T) {
 	// budget from the output budget.
 	cycle := make([]interface{}, 1)
 	cycle[0] = cycle
-	exactPath := strings.Repeat("#", maxExpansionOperations/2)
+	exactPath := strings.Repeat("#", issue27MaxExpansionOperations/2)
 	exact := Get(cycle, exactPath)
 	require.True(t, exact.Effective())
 	require.Len(t, exact.Values(), 1)
@@ -155,7 +162,7 @@ func TestIssue27_ResultMethodsShareOneCallBudget(t *testing.T) {
 
 	// Each item alone stays below the operation limit. Sharing one budget across
 	// both items is what makes the Result.Get/Result.GetE call exceed the cap.
-	path := strings.Repeat("#", maxExpansionOperations/4+1)
+	path := strings.Repeat("#", issue27MaxExpansionOperations/4+1)
 	requireExpansionLimitDiagnosis(t, base.Get(path))
 
 	result, err := base.GetE(path)
@@ -163,4 +170,54 @@ func TestIssue27_ResultMethodsShareOneCallBudget(t *testing.T) {
 	assert.ErrorIs(t, err, ErrExpansionLimit)
 	assert.False(t, result.Effective())
 	assert.Empty(t, result.Values())
+}
+
+func issue27NestedFanoutInput() []interface{} {
+	input := make([]interface{}, 10)
+	for i := range input {
+		input[i] = make([]int, 9_000)
+	}
+	return input
+}
+
+func TestIssue27_GetAccumulatesRetainedResults(t *testing.T) {
+	requireExpansionLimitDiagnosis(t, Get(issue27NestedFanoutInput(), "#.#"))
+}
+
+func TestIssue27_GetEAccumulatesRetainedResults(t *testing.T) {
+	result, err := GetE(issue27NestedFanoutInput(), "#.#")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, result.Effective())
+	assert.Empty(t, result.Values())
+}
+
+func TestIssue27_ResultGetAccumulatesRetainedResults(t *testing.T) {
+	requireExpansionLimitDiagnosis(t, Parse(issue27NestedFanoutInput()).Get("#.#"))
+}
+
+func TestIssue27_ResultGetEAccumulatesRetainedResults(t *testing.T) {
+	result, err := Parse(issue27NestedFanoutInput()).GetE("#.#")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExpansionLimit)
+	assert.False(t, result.Effective())
+	assert.Empty(t, result.Values())
+}
+
+func TestIssue27_PublicCallsHaveIndependentResultBudgets(t *testing.T) {
+	input := make([]int, 9_000)
+
+	for i := 0; i < 2; i++ {
+		require.Len(t, Get(input, "#").Values(), 9_000)
+
+		resultE, err := GetE(input, "#")
+		require.NoError(t, err)
+		require.Len(t, resultE.Values(), 9_000)
+
+		require.Len(t, Parse(input).Get("#").Values(), 9_000)
+
+		resultMethodE, err := Parse(input).GetE("#")
+		require.NoError(t, err)
+		require.Len(t, resultMethodE.Values(), 9_000)
+	}
 }

--- a/ognl.go
+++ b/ognl.go
@@ -12,6 +12,7 @@
 //     struct field name.
 //   - "#" expands the current value into a list: subsequent segments are then
 //     applied to every element (similar to flat-map). "##" expands twice.
+//     Expansion work and result count are bounded per Get/GetE call.
 //   - Use "\\" to escape a literal "." inside a key, e.g. "Foo\\.Bar".
 //
 // Concurrency: Get/GetE and the methods on a Result do not mutate their inputs
@@ -47,6 +48,10 @@ var ErrParseInt = errors.New("parse int error")
 var ErrUnableExpand = errors.New("unable to expand")
 
 var ErrInvalidValue = errors.New("invalid value")
+
+// ErrExpansionLimit reports that '#' expansion exceeded the fixed operation
+// or result limit for one Get/GetE call.
+var ErrExpansionLimit = errors.New("expansion limit exceeded")
 
 // Type classifies a Result's value. Its constants are declared in the same
 // order as the reflect.Kind constants, so Type(v.Kind()) is a safe conversion
@@ -244,17 +249,25 @@ func (r Result) Diagnosis() []error {
 // collected. It is safe to call Get repeatedly, and concurrently, on the same
 // Result: each call allocates its own backing slice and never mutates r.
 func (r Result) Get(path string) Result {
+	return r.get(path, &expansionBudget{})
+}
+
+func (r Result) get(path string, budget *expansionBudget) Result {
 	if r.deployment {
 		nr := r
 		src, _ := r.raw.([]interface{})
 		out := make([]interface{}, 0, len(src))
 		diag := append([]error(nil), r.diagnosis...)
 		for _, item := range src {
-			next := Get(item, path)
+			next := get(item, path, 0, budget)
+			diag = append(diag, next.diagnosis...)
+			if budget.err != nil {
+				nr.diagnosis = diag
+				return expansionLimitResult(nr, budget.err, item, path)
+			}
 			if next.typ != Invalid {
 				out = append(out, next.raw)
 			}
-			diag = append(diag, next.diagnosis...)
 		}
 		// Preserve the nil vs empty-slice distinction of the original raw so
 		// Value()/Values() stay observationally identical.
@@ -265,20 +278,30 @@ func (r Result) Get(path string) Result {
 		nr.diagnosis = diag
 		return nr
 	}
-	return Get(r.raw, path)
+	return get(r.raw, path, 0, budget)
 }
 
 // GetE is the error-returning form of Get. On an expanded Result it returns an
-// error only when no element matched path. Like Get, it never mutates r and is
-// safe to call concurrently.
+// error when no element matched path or when expansion exceeds its per-call
+// limit. Like Get, it never mutates r and is safe to call concurrently.
 func (r Result) GetE(path string) (Result, error) {
+	return r.getE(path, &expansionBudget{})
+}
+
+func (r Result) getE(path string, budget *expansionBudget) (Result, error) {
 	if r.deployment {
 		nr := r
 		src, _ := r.raw.([]interface{})
 		out := make([]interface{}, 0, len(src))
 		diag := append([]error(nil), r.diagnosis...)
 		for _, item := range src {
-			next, err := GetE(item, path)
+			next, err := getE(item, path, 0, budget)
+			if budget.err != nil || errors.Is(err, ErrExpansionLimit) {
+				if err == nil {
+					err = budget.err
+				}
+				return invalidExpansionResult(nr), wrapError(err, item, path)
+			}
 			if err != nil {
 				diag = append(diag, wrapError(err, item, path))
 			}
@@ -297,7 +320,7 @@ func (r Result) GetE(path string) (Result, error) {
 		}
 		return nr, nil
 	}
-	return GetE(r.raw, path)
+	return getE(r.raw, path, 0, budget)
 }
 
 // Parse wraps a value in a Result without navigating into it, so paths can be
@@ -310,10 +333,10 @@ func Parse(result interface{}) Result {
 // error describing the first fatal failure (it is the error-returning form of
 // Get). See the package doc for the path syntax.
 func GetE(value interface{}, path string) (Result, error) {
-	return getE(value, path, 0)
+	return getE(value, path, 0, &expansionBudget{})
 }
 
-func getE(value interface{}, path string, depth int) (Result, error) {
+func getE(value interface{}, path string, depth int, budget *expansionBudget) (Result, error) {
 	if depth > maxResolveDepth {
 		return Result{typ: Invalid, raw: value}, wrapError(ErrInvalidStructure, value, path)
 	}
@@ -347,7 +370,13 @@ func getE(value interface{}, path string, depth int) (Result, error) {
 				list := result.raw.([]interface{})
 				ln := len(list)
 				for i := 0; i < ln; i++ {
-					next, err := getE(list[i], path[index+1:], depth+1)
+					next, err := getE(list[i], path[index+1:], depth+1, budget)
+					if budget.err != nil || errors.Is(err, ErrExpansionLimit) {
+						if err == nil {
+							err = budget.err
+						}
+						return invalidExpansionResult(result), wrapError(err, list[i], path[index+1:])
+					}
 					if err != nil {
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], path[index+1:]))
 					}
@@ -385,6 +414,10 @@ func getE(value interface{}, path string, depth int) (Result, error) {
 				result.typ = Interface
 			}
 		case '#':
+			if err := budget.consumeOperations(1); err != nil {
+				result.deployment = true
+				return invalidExpansionResult(result), wrapError(err, result.raw, "#")
+			}
 			// 转化成slice 类型 平铺
 			switch result.deployment {
 			case true:
@@ -392,11 +425,17 @@ func getE(value interface{}, path string, depth int) (Result, error) {
 				list := result.raw.([]interface{})
 				ln := len(list)
 				for i := 0; i < ln; i++ {
-					raw, typ, err := deployment(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), 0)
+					raw, typ, err := deploymentWithBudget(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), 0, budget)
+					if errors.Is(err, ErrExpansionLimit) {
+						return invalidExpansionResult(result), wrapError(err, list[i], "#")
+					}
 					if err != nil {
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], "#"))
 					}
 					if typ != Invalid {
+						if err := budget.checkResults(len(list)-ln, len(raw)); err != nil {
+							return invalidExpansionResult(result), wrapError(err, list[i], "#")
+						}
 						list = append(list, raw...)
 					}
 				}
@@ -413,8 +452,11 @@ func getE(value interface{}, path string, depth int) (Result, error) {
 				// panic on the type assertion when deployment fails (e.g. on a
 				// scalar "#").
 				src := result.raw
-				raw, typ, err := deployment(reflect.TypeOf(src), reflect.ValueOf(src), 0)
+				raw, typ, err := deploymentWithBudget(reflect.TypeOf(src), reflect.ValueOf(src), 0, budget)
 				result.raw, result.typ = raw, typ
+				if errors.Is(err, ErrExpansionLimit) {
+					return invalidExpansionResult(result), wrapError(err, src, "#")
+				}
 				if err != nil {
 					return result, wrapError(err, src, "#")
 				}
@@ -479,14 +521,14 @@ func getE(value interface{}, path string, depth int) (Result, error) {
 
 // Get resolves path against value and returns the Result. It does not return an
 // error: an unresolved path yields a Result whose Effective reports false, and
-// non-fatal problems are recorded in Result.Diagnosis. Path length is bounded,
-// so adversarial paths cannot exhaust the stack. See the package doc for the
-// path syntax.
+// non-fatal problems are recorded in Result.Diagnosis. Expansion work and
+// result count are bounded, so adversarial '#' paths cannot exhaust memory or
+// CPU. See the package doc for the path syntax.
 func Get(value interface{}, path string) Result {
-	return get(value, path, 0)
+	return get(value, path, 0, &expansionBudget{})
 }
 
-func get(value interface{}, path string, depth int) Result {
+func get(value interface{}, path string, depth int, budget *expansionBudget) Result {
 	if depth > maxResolveDepth {
 		return Result{typ: Invalid, raw: value, diagnosis: []error{wrapError(ErrInvalidStructure, value, path)}}
 	}
@@ -519,11 +561,14 @@ func get(value interface{}, path string, depth int) Result {
 				list := result.raw.([]interface{})
 				ln := len(list)
 				for i := 0; i < ln; i++ {
-					next := get(list[i], path[index+1:], depth+1)
+					next := get(list[i], path[index+1:], depth+1, budget)
+					result.diagnosis = append(result.diagnosis, next.diagnosis...)
+					if budget.err != nil {
+						return expansionLimitResult(result, budget.err, list[i], path[index+1:])
+					}
 					if next.typ != Invalid {
 						list = append(list, next.raw)
 					}
-					result.diagnosis = append(result.diagnosis, next.diagnosis...)
 				}
 				result.raw = cloneTail(list, ln)
 				return result
@@ -548,6 +593,10 @@ func get(value interface{}, path string, depth int) Result {
 				result.typ = Interface
 			}
 		case '#':
+			if err := budget.consumeOperations(1); err != nil {
+				result.deployment = true
+				return expansionLimitResult(result, err, result.raw, "#")
+			}
 			// 转化成slice 类型 平铺
 			switch result.deployment {
 			case true:
@@ -555,11 +604,17 @@ func get(value interface{}, path string, depth int) Result {
 				list := result.raw.([]interface{})
 				ln := len(list)
 				for i := 0; i < ln; i++ {
-					raw, typ, err := deployment(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), 0)
+					raw, typ, err := deploymentWithBudget(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), 0, budget)
+					if errors.Is(err, ErrExpansionLimit) {
+						return expansionLimitResult(result, err, list[i], "#")
+					}
 					if err != nil {
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], "#"))
 					}
 					if typ != Invalid {
+						if err := budget.checkResults(len(list)-ln, len(raw)); err != nil {
+							return expansionLimitResult(result, err, list[i], "#")
+						}
 						list = append(list, raw...)
 					}
 				}
@@ -568,7 +623,10 @@ func get(value interface{}, path string, depth int) Result {
 				result.deployment = true
 				// Expand result.raw, not the stale entry value in tp/tv.
 				src := result.raw
-				raw, typ, err := deployment(reflect.TypeOf(src), reflect.ValueOf(src), 0)
+				raw, typ, err := deploymentWithBudget(reflect.TypeOf(src), reflect.ValueOf(src), 0, budget)
+				if errors.Is(err, ErrExpansionLimit) {
+					return expansionLimitResult(result, err, src, "#")
+				}
 				if err != nil {
 					result.diagnosis = append(result.diagnosis, wrapError(err, src, "#"))
 				}
@@ -667,6 +725,69 @@ func GetMany(value interface{}, path ...string) []Result {
 		results = append(results, Get(value, s))
 	}
 	return results
+}
+
+// The expansion limits are intentionally fixed and internal: they bound the
+// CPU work and retained result size of one public Get/GetE or Result.Get/GetE
+// call without adding configuration to the existing API. Ten thousand results
+// keep a returned []interface{} in the low hundreds of KiB, while the larger
+// operation allowance leaves room for normal fan-out and repeated expansion.
+// Each '#' and each value it scans consume one operation.
+const (
+	maxExpansionOperations = 100_000
+	maxExpansionResults    = 10_000
+)
+
+type expansionBudget struct {
+	operations int
+	err        error
+}
+
+func (b *expansionBudget) consumeOperations(count int) error {
+	if b == nil || count == 0 {
+		return nil
+	}
+	if b.err != nil {
+		return b.err
+	}
+	if count < 0 || count > maxExpansionOperations-b.operations {
+		b.err = fmt.Errorf("expansion operations exceed %d: %w", maxExpansionOperations, ErrExpansionLimit)
+		return b.err
+	}
+	b.operations += count
+	return nil
+}
+
+func (b *expansionBudget) checkResults(current, additional int) error {
+	if b == nil {
+		return nil
+	}
+	if b.err != nil {
+		return b.err
+	}
+	if current < 0 || additional < 0 || current > maxExpansionResults || additional > maxExpansionResults-current {
+		b.err = fmt.Errorf("expansion results exceed %d: %w", maxExpansionResults, ErrExpansionLimit)
+		return b.err
+	}
+	return nil
+}
+
+func invalidExpansionResult(result Result) Result {
+	result.typ = Invalid
+	result.raw = nil
+	result.deployment = true
+	return result
+}
+
+func expansionLimitResult(result Result, err error, object interface{}, path string) Result {
+	result = invalidExpansionResult(result)
+	for _, diagnosis := range result.diagnosis {
+		if errors.Is(diagnosis, ErrExpansionLimit) {
+			return result
+		}
+	}
+	result.diagnosis = append(result.diagnosis, wrapError(err, object, path))
+	return result
 }
 
 // maxResolveDepth bounds every recursive descent in this package: parseString
@@ -829,6 +950,10 @@ func parseInt(t reflect.Type, v reflect.Value, tokenValue int, depth int) (inter
 }
 
 func deployment(t reflect.Type, v reflect.Value, depth int) ([]interface{}, Type, error) {
+	return deploymentWithBudget(t, v, depth, nil)
+}
+
+func deploymentWithBudget(t reflect.Type, v reflect.Value, depth int, budget *expansionBudget) ([]interface{}, Type, error) {
 	if depth > maxResolveDepth {
 		return nil, Invalid, ErrUnableExpand
 	}
@@ -844,9 +969,15 @@ func deployment(t reflect.Type, v reflect.Value, depth int) ([]interface{}, Type
 		if !v.Elem().IsValid() {
 			return nil, Invalid, nil
 		}
-		return deployment(t, v.Elem(), depth+1)
+		return deploymentWithBudget(t, v.Elem(), depth+1, budget)
 
 	case reflect.Map:
+		if err := budget.consumeOperations(v.Len()); err != nil {
+			return nil, Invalid, err
+		}
+		if err := budget.checkResults(0, v.Len()); err != nil {
+			return nil, Invalid, err
+		}
 		var ret []interface{}
 		var tp Type = Interface
 
@@ -860,6 +991,12 @@ func deployment(t reflect.Type, v reflect.Value, depth int) ([]interface{}, Type
 		return ret, tp, nil
 
 	case reflect.Slice, reflect.Array:
+		if err := budget.consumeOperations(v.Len()); err != nil {
+			return nil, Invalid, err
+		}
+		if err := budget.checkResults(0, v.Len()); err != nil {
+			return nil, Invalid, err
+		}
 		var ret []interface{}
 		var tp Type = Interface
 
@@ -875,6 +1012,12 @@ func deployment(t reflect.Type, v reflect.Value, depth int) ([]interface{}, Type
 		return ret, tp, nil
 
 	case reflect.Struct:
+		if err := budget.consumeOperations(v.NumField()); err != nil {
+			return nil, Invalid, err
+		}
+		if err := budget.checkResults(0, v.NumField()); err != nil {
+			return nil, Invalid, err
+		}
 		var ret []interface{}
 
 		for i := 0; i < v.NumField(); i++ {
@@ -897,6 +1040,12 @@ func deployment(t reflect.Type, v reflect.Value, depth int) ([]interface{}, Type
 		return ret, Interface, nil
 
 	default:
+		if err := budget.consumeOperations(1); err != nil {
+			return nil, Invalid, err
+		}
+		if err := budget.checkResults(0, 1); err != nil {
+			return nil, Invalid, err
+		}
 		return []interface{}{v.Interface()}, Type(v.Kind()), ErrUnableExpand
 	}
 }

--- a/ognl.go
+++ b/ognl.go
@@ -168,6 +168,11 @@ type Result struct {
 	// diagnosis collects non-fatal errors encountered while traversing; it does
 	// not affect the returned value.
 	diagnosis []error
+
+	// retainedResults is internal accounting for expanded list slots reachable
+	// from raw during one resolve call. Public entry points always start a fresh
+	// budget; the field lets a parent account for nested child expansions.
+	retainedResults int
 }
 
 // Effective reports whether the Result carries a usable value: its Type is not
@@ -255,6 +260,7 @@ func (r Result) Get(path string) Result {
 func (r Result) get(path string, budget *expansionBudget) Result {
 	if r.deployment {
 		nr := r
+		nr.retainedResults = 0
 		src, _ := r.raw.([]interface{})
 		out := make([]interface{}, 0, len(src))
 		diag := append([]error(nil), r.diagnosis...)
@@ -266,7 +272,15 @@ func (r Result) get(path string, budget *expansionBudget) Result {
 				return expansionLimitResult(nr, budget.err, item, path)
 			}
 			if next.typ != Invalid {
+				if err := budget.retainResults(1); err != nil {
+					nr.diagnosis = diag
+					return expansionLimitResult(nr, err, item, path)
+				}
 				out = append(out, next.raw)
+				nr.retainedResults += next.retainedResults + 1
+			} else if err := budget.releaseResults(next.retainedResults); err != nil {
+				nr.diagnosis = diag
+				return expansionLimitResult(nr, err, item, path)
 			}
 		}
 		// Preserve the nil vs empty-slice distinction of the original raw so
@@ -291,6 +305,7 @@ func (r Result) GetE(path string) (Result, error) {
 func (r Result) getE(path string, budget *expansionBudget) (Result, error) {
 	if r.deployment {
 		nr := r
+		nr.retainedResults = 0
 		src, _ := r.raw.([]interface{})
 		out := make([]interface{}, 0, len(src))
 		diag := append([]error(nil), r.diagnosis...)
@@ -306,7 +321,13 @@ func (r Result) getE(path string, budget *expansionBudget) (Result, error) {
 				diag = append(diag, wrapError(err, item, path))
 			}
 			if next.typ != Invalid {
+				if err := budget.retainResults(1); err != nil {
+					return invalidExpansionResult(nr), wrapError(err, item, path)
+				}
 				out = append(out, next.raw)
+				nr.retainedResults += next.retainedResults + 1
+			} else if err := budget.releaseResults(next.retainedResults); err != nil {
+				return invalidExpansionResult(nr), wrapError(err, item, path)
 			}
 			diag = append(diag, next.diagnosis...)
 		}
@@ -369,6 +390,10 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 			case true:
 				list := result.raw.([]interface{})
 				ln := len(list)
+				if err := budget.releaseResults(result.retainedResults); err != nil {
+					return invalidExpansionResult(result), wrapError(err, list, path[index+1:])
+				}
+				result.retainedResults = 0
 				for i := 0; i < ln; i++ {
 					next, err := getE(list[i], path[index+1:], depth+1, budget)
 					if budget.err != nil || errors.Is(err, ErrExpansionLimit) {
@@ -381,7 +406,13 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], path[index+1:]))
 					}
 					if next.typ != Invalid {
+						if err := budget.retainResults(1); err != nil {
+							return invalidExpansionResult(result), wrapError(err, list[i], path[index+1:])
+						}
 						list = append(list, next.raw)
+						result.retainedResults += next.retainedResults + 1
+					} else if err := budget.releaseResults(next.retainedResults); err != nil {
+						return invalidExpansionResult(result), wrapError(err, list[i], path[index+1:])
 					}
 
 					result.diagnosis = append(result.diagnosis, next.diagnosis...)
@@ -424,6 +455,10 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 				// queue 展开
 				list := result.raw.([]interface{})
 				ln := len(list)
+				if err := budget.releaseResults(result.retainedResults); err != nil {
+					return invalidExpansionResult(result), wrapError(err, list, "#")
+				}
+				result.retainedResults = 0
 				for i := 0; i < ln; i++ {
 					raw, typ, err := deploymentWithBudget(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), 0, budget)
 					if errors.Is(err, ErrExpansionLimit) {
@@ -433,10 +468,10 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], "#"))
 					}
 					if typ != Invalid {
-						if err := budget.checkResults(len(list)-ln, len(raw)); err != nil {
-							return invalidExpansionResult(result), wrapError(err, list[i], "#")
-						}
 						list = append(list, raw...)
+						result.retainedResults += len(raw)
+					} else if err := budget.releaseResults(len(raw)); err != nil {
+						return invalidExpansionResult(result), wrapError(err, list[i], "#")
 					}
 				}
 				result.raw = cloneTail(list, ln)
@@ -457,6 +492,7 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 				if errors.Is(err, ErrExpansionLimit) {
 					return invalidExpansionResult(result), wrapError(err, src, "#")
 				}
+				result.retainedResults = len(raw)
 				if err != nil {
 					return result, wrapError(err, src, "#")
 				}
@@ -476,6 +512,10 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 				)
 				list := result.raw.([]interface{})
 				ln := len(list)
+				if err := budget.releaseResults(result.retainedResults); err != nil {
+					return invalidExpansionResult(result), wrapError(err, list, sv)
+				}
+				result.retainedResults = 0
 				for i := 0; i < ln; i++ {
 					if digit {
 						value, tp, err = parseInt(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), v, 0)
@@ -486,7 +526,11 @@ func getE(value interface{}, path string, depth int, budget *expansionBudget) (R
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], sv))
 					}
 					if tp != Invalid {
+						if err := budget.retainResults(1); err != nil {
+							return invalidExpansionResult(result), wrapError(err, list[i], sv)
+						}
 						list = append(list, value)
+						result.retainedResults++
 					}
 				}
 				result.raw = cloneTail(list, ln)
@@ -560,6 +604,10 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 			case true:
 				list := result.raw.([]interface{})
 				ln := len(list)
+				if err := budget.releaseResults(result.retainedResults); err != nil {
+					return expansionLimitResult(result, err, list, path[index+1:])
+				}
+				result.retainedResults = 0
 				for i := 0; i < ln; i++ {
 					next := get(list[i], path[index+1:], depth+1, budget)
 					result.diagnosis = append(result.diagnosis, next.diagnosis...)
@@ -567,7 +615,13 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 						return expansionLimitResult(result, budget.err, list[i], path[index+1:])
 					}
 					if next.typ != Invalid {
+						if err := budget.retainResults(1); err != nil {
+							return expansionLimitResult(result, err, list[i], path[index+1:])
+						}
 						list = append(list, next.raw)
+						result.retainedResults += next.retainedResults + 1
+					} else if err := budget.releaseResults(next.retainedResults); err != nil {
+						return expansionLimitResult(result, err, list[i], path[index+1:])
 					}
 				}
 				result.raw = cloneTail(list, ln)
@@ -603,6 +657,10 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 				// queue 展开
 				list := result.raw.([]interface{})
 				ln := len(list)
+				if err := budget.releaseResults(result.retainedResults); err != nil {
+					return expansionLimitResult(result, err, list, "#")
+				}
+				result.retainedResults = 0
 				for i := 0; i < ln; i++ {
 					raw, typ, err := deploymentWithBudget(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), 0, budget)
 					if errors.Is(err, ErrExpansionLimit) {
@@ -612,10 +670,10 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], "#"))
 					}
 					if typ != Invalid {
-						if err := budget.checkResults(len(list)-ln, len(raw)); err != nil {
-							return expansionLimitResult(result, err, list[i], "#")
-						}
 						list = append(list, raw...)
+						result.retainedResults += len(raw)
+					} else if err := budget.releaseResults(len(raw)); err != nil {
+						return expansionLimitResult(result, err, list[i], "#")
 					}
 				}
 				result.raw = cloneTail(list, ln)
@@ -631,6 +689,7 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 					result.diagnosis = append(result.diagnosis, wrapError(err, src, "#"))
 				}
 				result.raw, result.typ = raw, typ
+				result.retainedResults = len(raw)
 			}
 
 		default:
@@ -647,6 +706,10 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 				)
 				list := result.raw.([]interface{})
 				ln := len(list)
+				if err := budget.releaseResults(result.retainedResults); err != nil {
+					return expansionLimitResult(result, err, list, sv)
+				}
+				result.retainedResults = 0
 				for i := 0; i < ln; i++ {
 					if digit {
 						value, tp, err = parseInt(reflect.TypeOf(list[i]), reflect.ValueOf(list[i]), v, 0)
@@ -657,7 +720,11 @@ func get(value interface{}, path string, depth int, budget *expansionBudget) Res
 						result.diagnosis = append(result.diagnosis, wrapError(err, list[i], sv))
 					}
 					if tp != Invalid {
+						if err := budget.retainResults(1); err != nil {
+							return expansionLimitResult(result, err, list[i], sv)
+						}
 						list = append(list, value)
+						result.retainedResults++
 					}
 				}
 				result.raw = cloneTail(list, ln)
@@ -740,6 +807,7 @@ const (
 
 type expansionBudget struct {
 	operations int
+	results    int // expanded list slots currently retained across the result tree
 	err        error
 }
 
@@ -758,17 +826,33 @@ func (b *expansionBudget) consumeOperations(count int) error {
 	return nil
 }
 
-func (b *expansionBudget) checkResults(current, additional int) error {
-	if b == nil {
+func (b *expansionBudget) retainResults(count int) error {
+	if b == nil || count == 0 {
 		return nil
 	}
 	if b.err != nil {
 		return b.err
 	}
-	if current < 0 || additional < 0 || current > maxExpansionResults || additional > maxExpansionResults-current {
+	if count < 0 || count > maxExpansionResults-b.results {
 		b.err = fmt.Errorf("expansion results exceed %d: %w", maxExpansionResults, ErrExpansionLimit)
 		return b.err
 	}
+	b.results += count
+	return nil
+}
+
+func (b *expansionBudget) releaseResults(count int) error {
+	if b == nil || count == 0 {
+		return nil
+	}
+	if b.err != nil {
+		return b.err
+	}
+	if count < 0 || count > b.results {
+		b.err = fmt.Errorf("invalid expansion result accounting: %w", ErrExpansionLimit)
+		return b.err
+	}
+	b.results -= count
 	return nil
 }
 
@@ -776,6 +860,7 @@ func invalidExpansionResult(result Result) Result {
 	result.typ = Invalid
 	result.raw = nil
 	result.deployment = true
+	result.retainedResults = 0
 	return result
 }
 
@@ -975,7 +1060,7 @@ func deploymentWithBudget(t reflect.Type, v reflect.Value, depth int, budget *ex
 		if err := budget.consumeOperations(v.Len()); err != nil {
 			return nil, Invalid, err
 		}
-		if err := budget.checkResults(0, v.Len()); err != nil {
+		if err := budget.retainResults(v.Len()); err != nil {
 			return nil, Invalid, err
 		}
 		var ret []interface{}
@@ -994,7 +1079,7 @@ func deploymentWithBudget(t reflect.Type, v reflect.Value, depth int, budget *ex
 		if err := budget.consumeOperations(v.Len()); err != nil {
 			return nil, Invalid, err
 		}
-		if err := budget.checkResults(0, v.Len()); err != nil {
+		if err := budget.retainResults(v.Len()); err != nil {
 			return nil, Invalid, err
 		}
 		var ret []interface{}
@@ -1015,7 +1100,7 @@ func deploymentWithBudget(t reflect.Type, v reflect.Value, depth int, budget *ex
 		if err := budget.consumeOperations(v.NumField()); err != nil {
 			return nil, Invalid, err
 		}
-		if err := budget.checkResults(0, v.NumField()); err != nil {
+		if err := budget.retainResults(v.NumField()); err != nil {
 			return nil, Invalid, err
 		}
 		var ret []interface{}
@@ -1043,7 +1128,7 @@ func deploymentWithBudget(t reflect.Type, v reflect.Value, depth int, budget *ex
 		if err := budget.consumeOperations(1); err != nil {
 			return nil, Invalid, err
 		}
-		if err := budget.checkResults(0, 1); err != nil {
+		if err := budget.retainResults(1); err != nil {
 			return nil, Invalid, err
 		}
 		return []interface{}{v.Interface()}, Type(v.Kind()), ErrUnableExpand


### PR DESCRIPTION
## What

- 为每次 `Get`/`GetE` 及 `Result.Get`/`Result.GetE` 调用增加固定的 `#` 展开操作预算与结果预算。
- 新增可由 `errors.Is` 识别的 `ErrExpansionLimit`；超限时 `Get` fail closed 并写入 `Diagnosis()`，`GetE` 返回 fatal error，二者都不暴露部分结果。
- 补充指数展开、正好上限/超一、空/部分结果、嵌套累计输出、链式 Result 调用与 mutation 回归测试，并更新 README。

## Why

连续 `#` 不增加现有 `maxResolveDepth`，共享二叉对象图在 18 层即可从 1 个根放大为 262,144 个结果，攻击者可持续消耗 CPU 和内存。仅检查每个局部切片也不足以限制嵌套 fan-out：10 个各含 9,000 项的切片经 `#.#` 会在一次调用中保留 90,000 个叶子结果。

## How

- 每次公开调用创建一个局部预算，并在同一次调用的递归与所有已展开元素之间共享；不使用全局可变状态。
- 固定内部上限为 100,000 次展开操作和整个返回结果树中的 10,000 个 retained results。每个 `#` 及其扫描的每个值各计一次操作。
- Result 记录当前 raw 树的内部 retained ownership：顺序替换时释放旧平铺结果，父级保留嵌套 child 时累计 child results 与外层 slot，因此 sibling fan-out 无法分别绕过上限。
- 在遍历/分配容器结果前预留预算；任何预算错误都立即丢弃 partial output。
- 保留现有 API 形态，不新增 options、hook 或配置层；唯一新增公开符号是稳定 sentinel。

## Resource / Risk

- 10,000 个 `interface{}` 结果本身约占低数百 KiB，100,000 次操作限制连续一元素循环等低 fan-out 路径。
- 这是有意的兼容性收紧：原本可一次展开超过上限的调用现在会返回 `ErrExpansionLimit`。正常低于上限的展开、空结果和混合部分成功语义保持不变。
- 预算只存在于调用栈内，因此不同公开调用及并发只读调用之间互不影响。

## Tests

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go vet ./...`
- `golangci-lint run --new-from-rev origin/main ./...`
- 红测：旧实现对 18 层二叉共享图返回 262,144 个有效结果，且 `GetE` 无错误。
- Review 红测：10×9,000 的 `#.#` probe 在 Get/GetE/Result.Get/Result.GetE 四条路径全部绕过局部结果检查；修复后全部 fail closed。
- Contract mutation：实现常量改为 99,998/9,999 时，独立使用 100,000/10,000 字面契约的边界测试均失败。
- Guard mutation：分别绕过 operation limit、result limit 或将 retained 累计改成覆盖赋值后，对应边界和四 API probe 均失败；恢复实现后全套通过。

Fixes #27
