### PR TITLE
docs: define Result compatibility contract (#29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,29 @@ func main() {
 - 每次 `Get`/`GetE`（包括 `Result` 上的同名方法）的 `#` 展开最多执行 100,000 次操作，并在整个返回结果树中累计保留 10,000 个结果。超限时 `Get` 返回无效结果并在 `Diagnosis()` 中记录 `ErrExpansionLimit`，`GetE` 返回可由 `errors.Is` 识别的 `ErrExpansionLimit`，且不返回部分展开结果。
 - 所有错误都用 `%w` 包装,可用 `errors.Is(err, ognl.ErrInvalidValue)` 等判断;错误信息**只包含被遍历对象的类型名,不含其值**,避免泄露密码 / token 等敏感数据。
 
+## Result 兼容性契约
+
+以下编号不变量固定当前 pre-1.0 行为。`Type` 是遍历元数据,不要把它当作 `Value()` 的动态 Go 类型。
+
+1. **C1 — Type 元数据。** `Parse(v)` 和空路径从 `Interface` 开始;成功解析的非展开字段/下标使用解析结果的 kind。`#` 使用展开过程报告的元素 kind,空展开为 `Interface`;已经展开的结果继续映射时不会重新计算 `Type`。因此非空 `Get([]User{{Name: "a"}}, "#.Name")` 的 `Type` 是 `Struct`,而 empty `Get([]User{}, "#.Name")` 的 `Type` 是 `Interface`。
+2. **C2 — Effective 与 typed nil。** `Invalid` 一定无效;展开结果仅在列表非空时有效;非展开结果按保存的 interface 是否为 nil 判断。typed nil pointer/map/slice 保存在非 nil interface 中,所以 `Parse(typedNil).Effective()` 为 `true`,即使 `Value()` 中的动态值为 nil。
+3. **C3 — empty flat-map。** 对空集合执行第一个 `#` 会成功得到 `Interface`、empty、ineffective Result,`GetE` 不报错。再对这个已展开的空结果应用字段或第二个 `#` 时没有任何匹配:`Get` 仍返回 ineffective Result,`GetE` 返回包装的 `ErrInvalidValue`。
+4. **C4 — scalar Values。** `Values()` 是忽略展开错误的 best-effort API,所以标量 `42` 返回 `[]interface{}{42}`;`ValuesE()` 会报告同一次展开的错误,返回 nil values 和包装的 `ErrUnableExpand`。
+
+下表中的 `User` 表示 `type User struct { Name string }`。
+
+| 表达式 / API | `Type()` | `Effective()` | 其它可观察结果 |
+| --- | --- | --- | --- |
+| `Parse(42)` | `Interface` | `true` | `Values()==[42]`;`ValuesE()` 返回 nil、`ErrUnableExpand` |
+| `Get(User{Name: "a"}, "Name")` | `String` | `true` | `Values()==["a"]` |
+| `Get([]User{{Name: "a"}}, "#.Name")` | `Struct` | `true` | `Values()==["a"]` |
+| `Get([]User{}, "#")` | `Interface` | `false` | values 为 nil;对应 `GetE` 不报错 |
+| `Get([]User{}, "#.Name")` | `Interface` | `false` | values 为 nil;对应 `GetE` 返回 `ErrInvalidValue` |
+| `Get([]User{}, "##")` | `Interface` | `false` | values 为 nil;对应 `GetE` 返回 `ErrInvalidValue` |
+| `Parse((*User)(nil))`（typed nil map/slice 同理） | `Interface` | `true` | `Value()` 保存 typed nil |
+
+上述矩阵由 [`result_contract_test.go`](./result_contract_test.go) 的 C1–C4 characterization tests 锁定（核对日期:2026-07-10）。
+
 ## API
 
 - `Get(value interface{}, path string) Result`
@@ -95,7 +118,7 @@ func main() {
 - `Parse(result interface{}) Result`
 
 1. Result.Effective() // 判断值是否有效
-2. Result.Type() // 获取值类型
+2. Result.Type() // 获取遍历类型元数据(见 C1)
 3. Result.Value() // 获取值
 4. Result.Values() // 获取值列表,如果是数组,则展开数组,如果是单个值,那么数组只会有一个
 5. Result.ValuesE() // 带有错误返回

--- a/ognl.go
+++ b/ognl.go
@@ -15,6 +15,22 @@
 //     Expansion work and result count are bounded per Get/GetE call.
 //   - Use "\\" to escape a literal "." inside a key, e.g. "Foo\\.Bar".
 //
+// Result compatibility contract:
+//
+//   - C1: Type is traversal metadata, not necessarily the dynamic kind of
+//     Value. Parse/empty paths start at Interface; resolved non-expanded
+//     segments use the resolved kind; expansion uses the kind reported by the
+//     expansion, with Interface for an empty expansion. Mapping an already
+//     expanded Result does not recompute Type.
+//   - C2: Effective is false for Invalid and empty expanded results. Otherwise
+//     it tests whether the stored interface is nil, so an interface containing
+//     a typed nil pointer, map or slice is effective.
+//   - C3: the first expansion of an empty collection succeeds with an
+//     ineffective Result. A further segment or expansion has no matches, so
+//     Get stays ineffective and GetE returns ErrInvalidValue.
+//   - C4: Values ignores expansion errors and returns a scalar as one element;
+//     ValuesE returns nil and ErrUnableExpand for that scalar.
+//
 // Concurrency: Get/GetE and the methods on a Result do not mutate their inputs
 // and are safe to call concurrently on the same object or Result, as long as
 // the underlying object is not being mutated elsewhere.
@@ -53,10 +69,11 @@ var ErrInvalidValue = errors.New("invalid value")
 // or result limit for one Get/GetE call.
 var ErrExpansionLimit = errors.New("expansion limit exceeded")
 
-// Type classifies a Result's value. Its constants are declared in the same
-// order as the reflect.Kind constants, so Type(v.Kind()) is a safe conversion
-// that preserves the integer value (a test locks this invariant). Use the
-// Result.Type accessor rather than relying on the underlying integer.
+// Type is traversal metadata returned by Result.Type, not necessarily the
+// dynamic Go kind of Result.Value. Its constants are declared in the same order
+// as the reflect.Kind constants, so Type(v.Kind()) is a safe conversion that
+// preserves the integer value (a test locks this invariant). Use the Result.Type
+// accessor rather than relying on the underlying integer.
 type Type int
 
 const (
@@ -153,9 +170,9 @@ func (t Type) String() string {
 // Diagnosis, and descend further with Get/GetE (chaining). The zero value is an
 // invalid Result.
 type Result struct {
-	// typ is the value's Type. When the path used '#', the Result is expanded:
+	// typ is traversal metadata. When the path used '#', the Result is expanded:
 	// raw is a []interface{} and typ reflects the element kind reported by
-	// deployment (often Interface, e.g. for map[string]interface{}).
+	// deployment (often Interface, e.g. for map[string]interface{}). See C1.
 	typ Type
 
 	// raw is the resolved value. When expanded (see deployment) it is a
@@ -175,9 +192,10 @@ type Result struct {
 	retainedResults int
 }
 
-// Effective reports whether the Result carries a usable value: its Type is not
-// Invalid, and (for an expanded Result) the list is non-empty, or (otherwise)
-// the value is non-nil.
+// Effective reports whether the Result carries a usable value (contract C2):
+// its Type is not Invalid, and an expanded Result has at least one element, or
+// an unexpanded Result's stored interface is non-nil. An interface containing a
+// typed nil pointer, map or slice is therefore effective.
 func (r Result) Effective() bool {
 	if r.Type() == Invalid {
 		return false
@@ -191,7 +209,10 @@ func (r Result) Effective() bool {
 	return r.raw != nil
 }
 
-// Type returns the value's Type (Invalid if nothing was resolved).
+// Type returns traversal metadata (contract C1), not necessarily the dynamic
+// kind of Value. Parse and empty paths start at Interface; resolved
+// non-expanded segments and expansions update the metadata as described in the
+// package contract. Invalid means nothing was resolved.
 func (r Result) Type() Type {
 	return r.typ
 }
@@ -213,8 +234,9 @@ func (r Result) Value() interface{} {
 // Values returns the value as a slice: an expanded Result's elements directly,
 // an expandable single value (slice/array/map/struct) expanded, or otherwise a
 // one-element slice holding the value. Each call returns a fresh shallow slice;
-// element objects are not deep-copied. Expansion errors are ignored; use ValuesE
-// to observe them.
+// element objects are not deep-copied. Per contract C4, expansion errors are
+// ignored, so a scalar is returned as one element; use ValuesE to observe the
+// error.
 func (r Result) Values() []interface{} {
 
 	if r.deployment {
@@ -231,9 +253,9 @@ func (r Result) Values() []interface{} {
 	return v
 }
 
-// ValuesE is the error-returning form of Values: it returns a fresh shallow
-// slice on every successful call and reports an error when a single value could
-// not be expanded.
+// ValuesE is the error-returning form of Values (contract C4): it returns a
+// fresh shallow slice on every successful call. When a scalar cannot be
+// expanded, it returns nil values and an error wrapping ErrUnableExpand.
 func (r Result) ValuesE() ([]interface{}, error) {
 
 	if r.deployment {
@@ -318,7 +340,9 @@ func (r Result) get(path string, budget *expansionBudget) Result {
 
 // GetE is the error-returning form of Get. On an expanded Result it returns an
 // error when no element matched path or when expansion exceeds its per-call
-// limit. Like Get, it never mutates r and is safe to call concurrently.
+// limit. Per contract C3, creating an empty expansion succeeds, while applying
+// another path to it returns ErrInvalidValue. Like Get, it never mutates r and
+// is safe to call concurrently.
 func (r Result) GetE(path string) (Result, error) {
 	return r.getE(path, &expansionBudget{})
 }

--- a/result_contract_test.go
+++ b/result_contract_test.go
@@ -1,0 +1,148 @@
+package ognl_test
+
+import (
+	"errors"
+	"testing"
+
+	ognl "github.com/golang-infrastructure/go-ognl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type resultContractUser struct {
+	Name string
+}
+
+func TestResultContract_C1TypeMetadata(t *testing.T) {
+	tests := []struct {
+		name      string
+		result    ognl.Result
+		wantType  ognl.Type
+		effective bool
+		values    []interface{}
+	}{
+		{
+			name:      "Parse starts with interface metadata",
+			result:    ognl.Parse(42),
+			wantType:  ognl.Interface,
+			effective: true,
+			values:    []interface{}{42},
+		},
+		{
+			name:      "non-expanded field uses resolved kind",
+			result:    ognl.Get(resultContractUser{Name: "alice"}, "Name"),
+			wantType:  ognl.String,
+			effective: true,
+			values:    []interface{}{"alice"},
+		},
+		{
+			name:      "expanded projection keeps expansion metadata",
+			result:    ognl.Get([]resultContractUser{{Name: "alice"}}, "#.Name"),
+			wantType:  ognl.Struct,
+			effective: true,
+			values:    []interface{}{"alice"},
+		},
+		{
+			name:      "empty expanded projection has interface metadata",
+			result:    ognl.Get([]resultContractUser{}, "#.Name"),
+			wantType:  ognl.Interface,
+			effective: false,
+			values:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantType, tt.result.Type())
+			assert.Equal(t, tt.effective, tt.result.Effective())
+			assert.Equal(t, tt.values, tt.result.Values())
+		})
+	}
+}
+
+func TestResultContract_C2EffectiveTypedNil(t *testing.T) {
+	var (
+		pointer *resultContractUser
+		mapping map[string]int
+		slice   []int
+	)
+
+	tests := []struct {
+		name           string
+		result         ognl.Result
+		wantType       ognl.Type
+		effective      bool
+		valueEqualsNil bool
+	}{
+		{name: "zero Result", result: ognl.Result{}, wantType: ognl.Invalid, effective: false, valueEqualsNil: true},
+		{name: "untyped nil", result: ognl.Parse(nil), wantType: ognl.Interface, effective: false, valueEqualsNil: true},
+		{name: "typed nil pointer", result: ognl.Parse(pointer), wantType: ognl.Interface, effective: true, valueEqualsNil: false},
+		{name: "typed nil map", result: ognl.Parse(mapping), wantType: ognl.Interface, effective: true, valueEqualsNil: false},
+		{name: "typed nil slice", result: ognl.Parse(slice), wantType: ognl.Interface, effective: true, valueEqualsNil: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.wantType, tt.result.Type())
+			assert.Equal(t, tt.effective, tt.result.Effective())
+			assert.Equal(t, tt.valueEqualsNil, tt.result.Value() == nil)
+			assert.Nil(t, tt.result.Value())
+		})
+	}
+}
+
+func TestResultContract_C3EmptyFlatMap(t *testing.T) {
+	empty := []resultContractUser{}
+	tests := []struct {
+		path      string
+		geteError bool
+	}{
+		{path: "#", geteError: false},
+		{path: "#.Name", geteError: true},
+		{path: "##", geteError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			result := ognl.Get(empty, tt.path)
+			assert.Equal(t, ognl.Interface, result.Type())
+			assert.False(t, result.Effective())
+			assert.Nil(t, result.Values())
+
+			result, err := ognl.GetE(empty, tt.path)
+			if tt.geteError {
+				require.Error(t, err)
+				assert.True(t, errors.Is(err, ognl.ErrInvalidValue))
+			} else {
+				require.NoError(t, err)
+			}
+			assert.Equal(t, ognl.Interface, result.Type())
+			assert.False(t, result.Effective())
+			assert.Nil(t, result.Values())
+		})
+	}
+
+	expanded, err := ognl.GetE(empty, "#")
+	require.NoError(t, err)
+	for _, path := range []string{"Name", "#"} {
+		t.Run("Result.GetE "+path, func(t *testing.T) {
+			result, err := expanded.GetE(path)
+			require.Error(t, err)
+			assert.True(t, errors.Is(err, ognl.ErrInvalidValue))
+			assert.Equal(t, ognl.Interface, result.Type())
+			assert.False(t, result.Effective())
+			assert.Nil(t, result.Values())
+		})
+	}
+}
+
+func TestResultContract_C4ScalarValues(t *testing.T) {
+	result := ognl.Parse(42)
+
+	assert.Equal(t, []interface{}{42}, result.Values())
+
+	values, err := result.ValuesE()
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ognl.ErrUnableExpand))
+	assert.Nil(t, values)
+}


### PR DESCRIPTION
## What

- define the current Result compatibility contract as four numbered invariants in README and godoc
- add an external-package characterization matrix that uses only exported APIs, Type constants, and error sentinels
- replace ambiguous "value type" wording with traversal-metadata wording

## Why

Result.Type, typed nil effectiveness, empty flat-map, and scalar Values/ValuesE behavior were observable but not specified. The issue body also contains one incorrect fact: on current `main`, `Get([]User{}, "#.Name").Type()` is `Interface`, not `Struct`.

Fixes #29

## How

### Numbered contract

1. **C1 — Type metadata:** Parse/empty paths start at Interface; direct resolution uses the resolved kind; expansion reports expansion metadata and empty expansion is Interface.
2. **C2 — Effective and typed nil:** Invalid and empty deployed results are ineffective; an unexpanded interface containing a typed nil pointer/map/slice is effective.
3. **C3 — Empty flat-map:** the first empty `#` succeeds but is ineffective; a later segment or second `#` leaves Get ineffective and makes GetE return ErrInvalidValue.
4. **C4 — Scalar values:** Values best-effort returns `[42]`; ValuesE returns nil plus ErrUnableExpand.

### Documentation reconciliation

- **Accurate:** module/install path, path syntax, error wrapping/redaction, concurrency, and exported API claims were retained.
- **Ambiguous/stale:** "value type" descriptions in README and godoc were rewritten as traversal metadata.
- **Missing:** typed nil, empty flat-map, and scalar error semantics were added and linked to C1-C4 tests.
- **Orphans/conflicts:** no stale C1-C4 references or broken characterization links remain.

## Compatibility

This PR intentionally preserves current pre-1.0 behavior and changes no implementation. No release note is needed because there is no observable behavior change.

## Tests

There is no red/green bug-fix cycle: the characterization matrix passed on untouched `origin/main`, as expected for a docs-and-tests contract change.

- `go doc .`
- `test -z "$(gofmt -l .)" && git diff --check`
- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
