### PR TITLE
fix: isolate Result accessor slices (#30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ func main() {
 
 `Get`/`GetE` 及 `Result` 上的方法都不会修改入参,且每次调用各自分配返回切片,因此可以对同一个对象或同一个 `Result` 并发只读调用(前提是底层对象本身没有被其它地方并发修改)。
 
+`Result` 自有的切片通过访问器返回时会浅拷贝:`#` 展开后的 `Value()`、`Values()`、`ValuesE()` 以及 `Diagnosis()` 每次调用都返回独立的 slice backing,调用方修改切片元素不会污染 `Result` 或其它访问器结果。切片中的对象不会深拷贝,仍保持原有身份。非展开 `Value()` 返回解析出的值本身;若它是 slice 或 map,仍与调用方输入共享所有权。
+
 ## 错误处理
 
 - `Get` 不返回 error:无法解析时 `Result.Effective()` 返回 `false`,过程中的非致命错误记录在 `Result.Diagnosis()` 中。路径长度受限,对抗性路径不会耗尽调用栈。

--- a/issue30_test.go
+++ b/issue30_test.go
@@ -1,0 +1,230 @@
+package ognl_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	ognl "github.com/golang-infrastructure/go-ognl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type issue30Item struct {
+	Name string
+}
+
+func issue30DeployedResult() (ognl.Result, *issue30Item, *issue30Item) {
+	first := &issue30Item{Name: "first"}
+	second := &issue30Item{Name: "second"}
+	return ognl.Get([]*issue30Item{first, second}, "#"), first, second
+}
+
+func issue30ValuesE(t *testing.T, result ognl.Result) []interface{} {
+	t.Helper()
+	values, err := result.ValuesE()
+	require.NoError(t, err)
+	return values
+}
+
+func TestIssue30DeployedAccessorsReturnIndependentShallowSlices(t *testing.T) {
+	result, firstItem, _ := issue30DeployedResult()
+	replacement := &issue30Item{Name: "replacement"}
+
+	accessors := []struct {
+		name string
+		get  func() []interface{}
+	}{
+		{
+			name: "Value",
+			get: func() []interface{} {
+				return result.Value().([]interface{})
+			},
+		},
+		{name: "Values", get: result.Values},
+		{
+			name: "ValuesE",
+			get: func() []interface{} {
+				return issue30ValuesE(t, result)
+			},
+		},
+	}
+
+	for _, accessor := range accessors {
+		t.Run(accessor.name, func(t *testing.T) {
+			first := accessor.get()
+			second := accessor.get()
+			require.Len(t, first, 2)
+			require.Len(t, second, 2)
+
+			first[0] = replacement
+
+			assert.Same(t, firstItem, second[0], "separate calls must not share backing storage")
+			assert.Same(t, firstItem, accessor.get()[0], "caller mutation must not alter the Result")
+		})
+	}
+
+	value := result.Value().([]interface{})
+	value[0] = replacement
+	assert.Same(t, firstItem, result.Values()[0], "Value must not alias Values")
+
+	values := result.Values()
+	values[0] = replacement
+	assert.Same(t, firstItem, issue30ValuesE(t, result)[0], "Values must not alias ValuesE")
+
+	// The copy is intentionally shallow: the element object retains its identity.
+	result.Values()[0].(*issue30Item).Name = "updated"
+	assert.Equal(t, "updated", result.Value().([]interface{})[0].(*issue30Item).Name)
+}
+
+func TestIssue30DiagnosisReturnsIndependentSlice(t *testing.T) {
+	result := ognl.Get([]interface{}{[]int{10, 20}, 99}, "#1")
+	first := result.Diagnosis()
+	second := result.Diagnosis()
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+	require.ErrorIs(t, first[0], ognl.ErrParseInt)
+
+	first[0] = errors.New("caller replacement")
+
+	assert.ErrorIs(t, second[0], ognl.ErrParseInt)
+	assert.ErrorIs(t, result.Diagnosis()[0], ognl.ErrParseInt)
+
+	mapped := result.Get("")
+	require.NotEmpty(t, mapped.Diagnosis())
+	assert.ErrorIs(t, mapped.Diagnosis()[0], ognl.ErrParseInt)
+
+	mappedE, err := result.GetE("")
+	require.NoError(t, err)
+	require.NotEmpty(t, mappedE.Diagnosis())
+	assert.ErrorIs(t, mappedE.Diagnosis()[0], ognl.ErrParseInt)
+}
+
+func TestIssue30AccessorMutationDoesNotAffectResultGetOrGetE(t *testing.T) {
+	accessors := []struct {
+		name string
+		get  func(t *testing.T, result ognl.Result) []interface{}
+	}{
+		{
+			name: "Value",
+			get: func(t *testing.T, result ognl.Result) []interface{} {
+				return result.Value().([]interface{})
+			},
+		},
+		{
+			name: "Values",
+			get: func(t *testing.T, result ognl.Result) []interface{} {
+				return result.Values()
+			},
+		},
+		{
+			name: "ValuesE",
+			get: func(t *testing.T, result ognl.Result) []interface{} {
+				return issue30ValuesE(t, result)
+			},
+		},
+	}
+
+	for _, accessor := range accessors {
+		t.Run(accessor.name, func(t *testing.T) {
+			result, _, _ := issue30DeployedResult()
+			accessor.get(t, result)[0] = &issue30Item{Name: "replacement"}
+
+			assert.Equal(t, []interface{}{"first", "second"}, result.Get("Name").Values())
+
+			mapped, err := result.GetE("Name")
+			require.NoError(t, err)
+			assert.Equal(t, []interface{}{"first", "second"}, mapped.Values())
+		})
+	}
+}
+
+func TestIssue30AccessorCopiesPreserveNilAndEmpty(t *testing.T) {
+	nilResult := ognl.Get([]int{}, "#")
+	value := nilResult.Value().([]interface{})
+	assert.Nil(t, value)
+	assert.Nil(t, nilResult.Values())
+	valuesE, err := nilResult.ValuesE()
+	require.NoError(t, err)
+	assert.Nil(t, valuesE)
+	assert.Nil(t, nilResult.Diagnosis())
+
+	emptyResult := ognl.Get([]int{1}, "#.missing")
+	value = emptyResult.Value().([]interface{})
+	require.NotNil(t, value)
+	assert.Empty(t, value)
+
+	values := emptyResult.Values()
+	require.NotNil(t, values)
+	assert.Empty(t, values)
+
+	valuesE, err = emptyResult.ValuesE()
+	require.NoError(t, err)
+	require.NotNil(t, valuesE)
+	assert.Empty(t, valuesE)
+}
+
+func TestIssue30NonDeployedValueOwnershipRemainsUnchanged(t *testing.T) {
+	slice := []int{1, 2}
+	sliceValue := ognl.Parse(slice).Value().([]int)
+	sliceValue[0] = 9
+	assert.Equal(t, []int{9, 2}, slice)
+
+	mapping := map[string]int{"value": 1}
+	mapValue := ognl.Parse(mapping).Value().(map[string]int)
+	mapValue["value"] = 9
+	assert.Equal(t, 9, mapping["value"])
+}
+
+func TestIssue30ConcurrentAccessorMutationAndResultReads(t *testing.T) {
+	const size = 16
+	items := make([]*issue30Item, size)
+	for i := range items {
+		items[i] = &issue30Item{Name: "original"}
+	}
+	result := ognl.Get(items, "#")
+	diagnosed := ognl.Get([]interface{}{[]int{10, 20}, 99}, "#1")
+	replacement := &issue30Item{Name: "replacement"}
+	replacementErr := errors.New("caller replacement")
+
+	var wg sync.WaitGroup
+	for i := 0; i < size; i++ {
+		i := i
+		wg.Add(5)
+		go func() {
+			defer wg.Done()
+			result.Value().([]interface{})[i] = replacement
+		}()
+		go func() {
+			defer wg.Done()
+			result.Values()[i] = replacement
+		}()
+		go func() {
+			defer wg.Done()
+			values, err := result.ValuesE()
+			if err != nil {
+				t.Errorf("ValuesE: %v", err)
+				return
+			}
+			values[i] = replacement
+		}()
+		go func() {
+			defer wg.Done()
+			diagnosed.Diagnosis()[0] = replacementErr
+		}()
+		go func() {
+			defer wg.Done()
+			_ = result.Get("Name")
+			_, _ = result.GetE("Name")
+		}()
+	}
+	wg.Wait()
+
+	assert.Equal(t, []interface{}{
+		"original", "original", "original", "original",
+		"original", "original", "original", "original",
+		"original", "original", "original", "original",
+		"original", "original", "original", "original",
+	}, result.Get("Name").Values())
+	assert.ErrorIs(t, diagnosed.Diagnosis()[0], ognl.ErrParseInt)
+}

--- a/ognl.go
+++ b/ognl.go
@@ -186,23 +186,32 @@ func (r Result) Type() Type {
 	return r.typ
 }
 
-// Value returns the resolved value as-is. For an expanded Result (via '#') it
-// is a []interface{}; otherwise it is the single resolved value (possibly nil).
+// Value returns the resolved value. For an expanded Result (via '#') it returns
+// a fresh shallow copy of the []interface{} on every call. Otherwise it returns
+// the single resolved value as-is (possibly nil); a slice or map in that value
+// therefore retains its original ownership and is not copied.
 func (r Result) Value() interface{} {
+	if r.deployment {
+		if r.raw == nil {
+			return nil
+		}
+		return cloneTail(r.raw.([]interface{}), 0)
+	}
 	return r.raw
 }
 
 // Values returns the value as a slice: an expanded Result's elements directly,
 // an expandable single value (slice/array/map/struct) expanded, or otherwise a
-// one-element slice holding the value. Expansion errors are ignored; use
-// ValuesE to observe them.
+// one-element slice holding the value. Each call returns a fresh shallow slice;
+// element objects are not deep-copied. Expansion errors are ignored; use ValuesE
+// to observe them.
 func (r Result) Values() []interface{} {
 
 	if r.deployment {
 		if r.raw == nil {
 			return nil
 		}
-		return r.raw.([]interface{})
+		return cloneTail(r.raw.([]interface{}), 0)
 	}
 
 	v, t, _ := deployment(reflect.TypeOf(r.raw), reflect.ValueOf(r.raw), 0)
@@ -212,15 +221,16 @@ func (r Result) Values() []interface{} {
 	return v
 }
 
-// ValuesE is the error-returning form of Values: it reports an error when a
-// single value could not be expanded.
+// ValuesE is the error-returning form of Values: it returns a fresh shallow
+// slice on every successful call and reports an error when a single value could
+// not be expanded.
 func (r Result) ValuesE() ([]interface{}, error) {
 
 	if r.deployment {
 		if r.raw == nil {
 			return nil, nil
 		}
-		return r.raw.([]interface{}), nil
+		return cloneTail(r.raw.([]interface{}), 0), nil
 	}
 
 	v, t, err := deployment(reflect.TypeOf(r.raw), reflect.ValueOf(r.raw), 0)
@@ -233,10 +243,16 @@ func (r Result) ValuesE() ([]interface{}, error) {
 	return v, nil
 }
 
-// Diagnosis returns the non-fatal errors collected while traversing. Each is
-// wrapped with %w, so errors.Is works against the package's sentinel errors.
+// Diagnosis returns a fresh shallow slice of the non-fatal errors collected
+// while traversing. Each error is wrapped with %w, so errors.Is works against
+// the package's sentinel errors.
 func (r Result) Diagnosis() []error {
-	return r.diagnosis
+	if r.diagnosis == nil {
+		return nil
+	}
+	diagnosis := make([]error, len(r.diagnosis))
+	copy(diagnosis, r.diagnosis)
+	return diagnosis
 }
 
 // Get applies path to a Result. When the Result is an expanded list (created


### PR DESCRIPTION
## What

- Return fresh shallow slice copies from deployed Result.Value, Result.Values, Result.ValuesE, and Result.Diagnosis.
- Preserve nil versus non-nil empty slices, element identity, and the existing non-deployed Value ownership behavior.
- Document the ownership boundary and add accessor, chaining, and race regression coverage.

## Why

The accessors exposed Result-owned slice backing arrays. Mutating one returned slice could corrupt later accessors and Result.Get/GetE calls, contradicting the documented isolation guarantee and creating caller-induced races.

## How

- Reuse the existing nil/empty-preserving shallow slice copy for deployed values.
- Copy the diagnosis slice before returning it while retaining the same wrapped error objects.
- Keep non-deployed Value unchanged, so caller-provided slices and maps remain borrowed rather than deep-copied.

## Tests

- go test -run '^TestIssue30' -count=1 ./...
- go test -count=1 ./...
- go test -race -count=1 ./...
- go vet ./...
- golangci-lint run --new-from-rev origin/main ./...
- Mutation checks: restoring direct returns independently for Value, Values, ValuesE, or Diagnosis makes the corresponding regression test fail.

Fixes #30