### PR TITLE
fix: return direct anonymous struct fields by index (#31)

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -670,8 +670,9 @@ func GetMany(value interface{}, path ...string) []Result {
 }
 
 // maxResolveDepth bounds every recursive descent in this package: parseString
-// and parseInt (pointer deref + anonymous-field promotion), deployment (pointer
-// /interface deref), and the get/getE expansion of "#." segments. Cyclic data
+// (pointer deref + anonymous-field promotion), parseInt (pointer deref),
+// deployment (pointer/interface deref), and the get/getE expansion of "#."
+// segments. Cyclic data
 // (a self-pointing embedded field, a self-referential interface) or an
 // adversarial "#.#.#..." path would otherwise recurse forever and hit an
 // unrecoverable fatal "stack overflow". Past the cap the walk stops with an
@@ -811,15 +812,6 @@ func parseInt(t reflect.Type, v reflect.Value, tokenValue int, depth int) (inter
 		value = cp.Field(tokenValue)
 
 		res := reflect.NewAt(value.Type(), unsafe.Pointer(value.UnsafeAddr())).Elem().Interface()
-
-		rt := t.Field(tokenValue)
-
-		if rt.Anonymous {
-			nv, nt, ne := parseInt(reflect.TypeOf(res), reflect.ValueOf(res), tokenValue, depth+1)
-			if ne == nil && nt != Invalid {
-				return nv, nt, ne
-			}
-		}
 
 		return res, Type(value.Kind()), nil
 

--- a/struct_index_test.go
+++ b/struct_index_test.go
@@ -1,0 +1,189 @@
+package ognl_test
+
+import (
+	"errors"
+	"testing"
+
+	ognl "github.com/golang-infrastructure/go-ognl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Issue31ExportedInner struct {
+	Name  string
+	Count int
+}
+
+type issue31PrivateInner struct {
+	Name  string
+	Count int
+}
+
+type issue31ExportedValueOuter struct {
+	Issue31ExportedInner
+	Tail bool
+}
+
+type issue31ExportedPointerOuter struct {
+	*Issue31ExportedInner
+	Tail bool
+}
+
+type issue31PrivateValueOuter struct {
+	issue31PrivateInner
+	Tail bool
+}
+
+type issue31PrivatePointerOuter struct {
+	*issue31PrivateInner
+	Tail bool
+}
+
+type issue31EmbeddingCase struct {
+	name             string
+	value            interface{}
+	embedded         interface{}
+	embeddedSelector string
+	promotedName     string
+	wantType         ognl.Type
+}
+
+func issue31EmbeddingCases() []issue31EmbeddingCase {
+	exportedPointer := &Issue31ExportedInner{Name: "exported-pointer", Count: 2}
+	privatePointer := &issue31PrivateInner{Name: "private-pointer", Count: 4}
+
+	return []issue31EmbeddingCase{
+		{
+			name:             "exported value",
+			value:            issue31ExportedValueOuter{Issue31ExportedInner: Issue31ExportedInner{Name: "exported-value", Count: 1}, Tail: true},
+			embedded:         Issue31ExportedInner{Name: "exported-value", Count: 1},
+			embeddedSelector: "Issue31ExportedInner",
+			promotedName:     "exported-value",
+			wantType:         ognl.Struct,
+		},
+		{
+			name:             "exported pointer",
+			value:            issue31ExportedPointerOuter{Issue31ExportedInner: exportedPointer, Tail: true},
+			embedded:         exportedPointer,
+			embeddedSelector: "Issue31ExportedInner",
+			promotedName:     "exported-pointer",
+			wantType:         ognl.Pointer,
+		},
+		{
+			name:             "private value",
+			value:            issue31PrivateValueOuter{issue31PrivateInner: issue31PrivateInner{Name: "private-value", Count: 3}, Tail: true},
+			embedded:         issue31PrivateInner{Name: "private-value", Count: 3},
+			embeddedSelector: "issue31PrivateInner",
+			promotedName:     "private-value",
+			wantType:         ognl.Struct,
+		},
+		{
+			name:             "private pointer",
+			value:            issue31PrivatePointerOuter{issue31PrivateInner: privatePointer, Tail: true},
+			embedded:         privatePointer,
+			embeddedSelector: "issue31PrivateInner",
+			promotedName:     "private-pointer",
+			wantType:         ognl.Pointer,
+		},
+	}
+}
+
+func TestIssue31_StructIndexReturnsDirectEmbeddedField(t *testing.T) {
+	for _, tt := range issue31EmbeddingCases() {
+		t.Run(tt.name+"/Get", func(t *testing.T) {
+			embedded := ognl.Get(tt.value, "0")
+			assert.Equal(t, tt.wantType, embedded.Type())
+			assert.Equal(t, tt.embedded, embedded.Value())
+			assert.Equal(t, true, ognl.Get(tt.value, "1").Value())
+		})
+
+		t.Run(tt.name+"/GetE", func(t *testing.T) {
+			embedded, err := ognl.GetE(tt.value, "0")
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantType, embedded.Type())
+			assert.Equal(t, tt.embedded, embedded.Value())
+
+			tail, err := ognl.GetE(tt.value, "1")
+			require.NoError(t, err)
+			assert.Equal(t, true, tail.Value())
+		})
+	}
+}
+
+func TestIssue31_StructNameSelectorsRemainUnchanged(t *testing.T) {
+	for _, tt := range issue31EmbeddingCases() {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.promotedName, ognl.Get(tt.value, "Name").Value())
+			assert.Equal(t, tt.embedded, ognl.Get(tt.value, tt.embeddedSelector).Value())
+
+			promoted, err := ognl.GetE(tt.value, "Name")
+			require.NoError(t, err)
+			assert.Equal(t, tt.promotedName, promoted.Value())
+
+			embedded, err := ognl.GetE(tt.value, tt.embeddedSelector)
+			require.NoError(t, err)
+			assert.Equal(t, tt.embedded, embedded.Value())
+		})
+	}
+}
+
+type Issue31NameCollision struct {
+	Issue31NameCollision string
+}
+
+type issue31NameCollisionOuter struct {
+	*Issue31NameCollision
+}
+
+func TestIssue31_AnonymousNameSelectorPromotionRemainsUnchanged(t *testing.T) {
+	value := issue31NameCollisionOuter{
+		Issue31NameCollision: &Issue31NameCollision{Issue31NameCollision: "promoted"},
+	}
+
+	assert.Equal(t, "promoted", ognl.Get(value, "Issue31NameCollision").Value())
+	result, err := ognl.GetE(value, "Issue31NameCollision")
+	require.NoError(t, err)
+	assert.Equal(t, "promoted", result.Value())
+}
+
+func TestIssue31_StructIndexOutOfBoundsRemainsTyped(t *testing.T) {
+	value := issue31ExportedValueOuter{}
+
+	result := ognl.Get(value, "2")
+	require.NotEmpty(t, result.Diagnosis())
+	assert.True(t, errors.Is(result.Diagnosis()[0], ognl.ErrStructIndexOutOfBounds))
+
+	_, err := ognl.GetE(value, "2")
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, ognl.ErrStructIndexOutOfBounds))
+}
+
+func TestIssue31_NilEmbeddedPointerIndexRemainsDirect(t *testing.T) {
+	tests := []struct {
+		name  string
+		value interface{}
+	}{
+		{name: "exported", value: issue31ExportedPointerOuter{Tail: true}},
+		{name: "private", value: issue31PrivatePointerOuter{Tail: true}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ognl.Get(tt.value, "0")
+			assert.Equal(t, ognl.Pointer, result.Type())
+			assert.True(t, result.Effective())
+			assert.Nil(t, result.Value())
+			assert.Equal(t, true, ognl.Get(tt.value, "1").Value())
+
+			result, err := ognl.GetE(tt.value, "0")
+			require.NoError(t, err)
+			assert.Equal(t, ognl.Pointer, result.Type())
+			assert.True(t, result.Effective())
+			assert.Nil(t, result.Value())
+
+			tail, err := ognl.GetE(tt.value, "1")
+			require.NoError(t, err)
+			assert.Equal(t, true, tail.Value())
+		})
+	}
+}


### PR DESCRIPTION
## What

- make numeric struct selectors return the requested direct field even when it is anonymous
- add black-box Get/GetE coverage for exported/private value and pointer embeddings
- lock name-selector promotion, Tail indexing, out-of-bounds errors, and nil embedded pointers

## Why

After selecting struct field N, `parseInt` recursively applied the same N to anonymous fields. Index `0` therefore returned the embedded value's own field 0 instead of the outer struct's direct embedded field, contradicting the documented numeric-index contract.

Fixes #31

## How

Remove only the anonymous-field recursion from the struct branch of `parseInt`. Pointer/interface dereferencing, private-field unsafe access, bounds checks, and `parseString` anonymous name promotion remain unchanged.

## Tests

- red test reproduced the wrong inner string for Get/GetE across exported/private value and pointer embeddings
- restoring the removed recursion made the direct-field matrix fail again
- `test -z "$(gofmt -l .)" && git diff --check`
- `go vet ./...`
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -gcflags=all=-d=checkptr=2 ./... -count=1`
- `GOTOOLCHAIN=go1.18.10 go test ./... -count=1`
- `golangci-lint run --new-from-rev origin/main ./...`
