### PR TITLE
test: add GetE mutation gates and CI (#34)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Go ${{ matrix.go-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version:
+          - '1.18.x'
+          - 'stable'
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache-dependency-path: go.sum
+
+      - name: Verify formatting
+        run: |
+          gofmt -w .
+          git diff --exit-code
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./... -count=1
+
+      - name: Race test
+        run: go test -race ./... -count=1
+
+      - name: Check pointer safety
+        run: go test -gcflags=all=-d=checkptr=2 ./... -count=1
+
+      - name: Fuzz selectors
+        if: matrix.go-version == 'stable'
+        run: go test ./... -run '^$' -fuzz '^FuzzSelectorNoPanic$' -fuzztime=5s
+
+      - name: Install govulncheck
+        if: matrix.go-version == 'stable'
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+
+      - name: Scan for vulnerabilities
+        if: matrix.go-version == 'stable'
+        run: govulncheck ./...

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,53 @@
+package ognl
+
+import (
+	"strings"
+	"testing"
+)
+
+func FuzzSelectorNoPanic(f *testing.F) {
+	seeds := []string{
+		"",
+		"escaped\\.key",
+		"users#.name",
+		strings.Repeat(".", 4096) + "users",
+		string([]byte{0xff, '\\', '.', '#', 0xfe, 0x00}),
+	}
+	for _, seed := range seeds {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, selector string) {
+		value := map[string]interface{}{
+			"escaped.key": "escaped",
+			"nil":         nil,
+			"users": []interface{}{
+				map[string]interface{}{"name": "alice", "tags": []string{"admin"}},
+				map[string]interface{}{"name": "bob", "tags": []string{"viewer"}},
+			},
+		}
+
+		results := []Result{Get(value, selector)}
+		result, _ := GetE(value, selector)
+		results = append(results, result)
+
+		parsed := Parse(value)
+		results = append(results, parsed.Get(selector))
+		result, _ = parsed.GetE(selector)
+		results = append(results, result)
+
+		deployed := Get(value, "users#")
+		results = append(results, deployed.Get(selector))
+		result, _ = deployed.GetE(selector)
+		results = append(results, result)
+
+		for _, result := range results {
+			_ = result.Effective()
+			_ = result.Type()
+			_ = result.Value()
+			_ = result.Values()
+			_, _ = result.ValuesE()
+			_ = result.Diagnosis()
+		}
+	})
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -79,6 +79,20 @@ func TestP0_3_HashExpandsResolvedValue(t *testing.T) {
 	assert.ElementsMatch(t, []interface{}{"alice", "bob"}, names)
 }
 
+func TestP0_3_GetEHashExpandsResolvedValue(t *testing.T) {
+	value := map[string]interface{}{
+		"users": []interface{}{
+			map[string]interface{}{"name": "alice"},
+			map[string]interface{}{"name": "bob"},
+		},
+		"other": 1,
+	}
+
+	result, err := GetE(value, "users#.name")
+	require.NoError(t, err)
+	assert.Equal(t, []interface{}{"alice", "bob"}, result.Values())
+}
+
 // P0-4: a map keyed by a defined type (type K string / type K int) used to
 // panic inside reflect.Value.MapIndex.
 type namedKey string
@@ -142,6 +156,52 @@ func TestP0_5_ResultGet_NoSequentialCorruption(t *testing.T) {
 	require.Equal(t, []interface{}{10, 20, 30}, b.Values())
 
 	// With the old list[ln:] aliasing, b's appends overwrite a's slice in place.
+	assert.Equal(t, []interface{}{1, 2, 3}, a.Values(), "a must be unaffected by b")
+}
+
+func TestP0_5_ResultGetE_Concurrent(t *testing.T) {
+	type item struct {
+		Name string
+		Tags []string
+	}
+	value := []item{
+		{Name: "a", Tags: []string{"x"}},
+		{Name: "b", Tags: []string{"u"}},
+		{Name: "c", Tags: []string{"p"}},
+	}
+	r := Get(value, "#")
+	require.True(t, r.Effective())
+
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			path := "Name"
+			if i%2 == 0 {
+				path = "Tags"
+			}
+			_, _ = r.GetE(path)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestP0_5_ResultGetE_NoSequentialCorruption(t *testing.T) {
+	big := make([]interface{}, 3, 64)
+	big[0] = map[string]interface{}{"k": 1, "j": 10}
+	big[1] = map[string]interface{}{"k": 2, "j": 20}
+	big[2] = map[string]interface{}{"k": 3, "j": 30}
+	r := Result{deployment: true, raw: big, typ: Interface}
+
+	a, err := r.GetE("k")
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{1, 2, 3}, a.Values())
+
+	b, err := r.GetE("j")
+	require.NoError(t, err)
+	require.Equal(t, []interface{}{10, 20, 30}, b.Values())
+
 	assert.Equal(t, []interface{}{1, 2, 3}, a.Values(), "a must be unaffected by b")
 }
 


### PR DESCRIPTION
## What

- Add GetE mirrors for mid-path `#` expansion and deployed Result isolation, including race coverage.
- Add a selector no-panic fuzz target covering top-level and Result Get/GetE paths.
- Add a least-privilege GitHub Actions matrix for Go 1.18 and the current stable release.

## Why

The existing green suite did not detect two confirmed regressions: GetE expanding the root instead of the resolved mid-path value, and deployed Result.GetE reusing the source backing array. The repository also had no CI or fuzz gate.

Fixes #34

## How

- Assert GetE expands `users` before applying `.name`.
- Force spare capacity in a deployed Result and prove sequential GetE calls cannot overwrite one another; mirror the concurrency test for race detection.
- Exercise empty, escaped, `#`, long, and invalid-byte selectors through Get/GetE and Result.Get/GetE.
- Pin official checkout/setup-go releases to immutable commit SHAs, grant only `contents: read`, and run bounded fuzzing plus pinned `govulncheck@v1.1.4` only on stable Go.

## Mutation proof

- M1 (`src := value` in mid-path GetE `#`): focused test failed by returning the expanded root values instead of `alice` and `bob`.
- M2 (`out := src[:0]` in deployed Result.GetE): focused test failed because the second query observed the first query's overwritten backing array.

## Validation

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -gcflags=all=-d=checkptr=2 ./... -count=1`
- `go vet ./...`
- `golangci-lint run --new-from-rev=origin/main ./...`
- Go 1.18.10: vet, test, race, and checkptr
- `go test ./... -run '^$' -fuzz '^FuzzSelectorNoPanic$' -fuzztime=5s` (1,081,768 executions)
- `govulncheck@v1.1.4 ./...` (no reachable vulnerabilities)

Coverage is 73.3% overall; Result.GetE is 90%. No coverage threshold is introduced.
