### PR TITLE
fix: keep Invalid Result accessors empty (#55)

### DIFF
--- a/ognl.go
+++ b/ognl.go
@@ -249,11 +249,14 @@ func (r Result) Value() interface{} {
 
 // Values returns the value as a slice: an expanded Result's elements directly,
 // an expandable single value (slice/array/map/struct) expanded, or otherwise a
-// one-element slice holding the value. Each call returns a fresh shallow slice;
-// element objects are not deep-copied. Per contract C4, expansion errors are
-// ignored, so a scalar is returned as one element; use ValuesE to observe the
-// error.
+// one-element slice holding the value. An Invalid Result returns nil. Each call
+// returns a fresh shallow slice; element objects are not deep-copied. Per
+// contract C4, expansion errors are ignored, so a scalar is returned as one
+// element; use ValuesE to observe the error.
 func (r Result) Values() []interface{} {
+	if r.Type() == Invalid {
+		return nil
+	}
 
 	if r.deployment {
 		if r.raw == nil {
@@ -270,9 +273,13 @@ func (r Result) Values() []interface{} {
 }
 
 // ValuesE is the error-returning form of Values (contract C4): it returns a
-// fresh shallow slice on every successful call. When a scalar cannot be
-// expanded, it returns nil values and an error wrapping ErrUnableExpand.
+// fresh shallow slice on every successful call. An Invalid Result returns nil
+// values and no error. When a scalar cannot be expanded, it returns nil values
+// and an error wrapping ErrUnableExpand.
 func (r Result) ValuesE() ([]interface{}, error) {
+	if r.Type() == Invalid {
+		return nil, nil
+	}
 
 	if r.deployment {
 		if r.raw == nil {

--- a/result_contract_test.go
+++ b/result_contract_test.go
@@ -146,3 +146,53 @@ func TestResultContract_C4ScalarValues(t *testing.T) {
 	assert.True(t, errors.Is(err, ognl.ErrUnableExpand))
 	assert.Nil(t, values)
 }
+
+func TestResultContract_InvalidValuesAreEmpty(t *testing.T) {
+	invalidSelectorE, err := ognl.GetE(map[string]int{"present": 1}, `missing\`)
+	require.Error(t, err)
+	missingE, err := ognl.GetE(resultContractUser{Name: "alice"}, "Missing")
+	require.Error(t, err)
+	outOfRangeE, err := ognl.GetE([]int{1}, "2")
+	require.Error(t, err)
+
+	tests := []struct {
+		name   string
+		result ognl.Result
+	}{
+		{name: "zero Result", result: ognl.Result{}},
+		{name: "Get invalid selector", result: ognl.Get(map[string]int{"present": 1}, `missing\`)},
+		{name: "GetE invalid selector", result: invalidSelectorE},
+		{name: "Get missing field", result: ognl.Get(resultContractUser{Name: "alice"}, "Missing")},
+		{name: "GetE missing field", result: missingE},
+		{name: "Get index out of range", result: ognl.Get([]int{1}, "2")},
+		{name: "GetE index out of range", result: outOfRangeE},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, ognl.Invalid, tt.result.Type())
+			assert.False(t, tt.result.Effective())
+			assert.Nil(t, tt.result.Value())
+			assert.Nil(t, tt.result.Values())
+
+			values, err := tt.result.ValuesE()
+			require.NoError(t, err)
+			assert.Nil(t, values)
+		})
+	}
+}
+
+func TestResultContract_InvalidValuesPreserveTypedNil(t *testing.T) {
+	var pointer *resultContractUser
+	result := ognl.Parse(pointer)
+
+	assert.Equal(t, ognl.Interface, result.Type())
+	assert.True(t, result.Effective())
+	require.Len(t, result.Values(), 1)
+	assert.Nil(t, result.Values()[0])
+
+	values, err := result.ValuesE()
+	require.NoError(t, err)
+	require.Len(t, values, 1)
+	assert.Nil(t, values[0])
+}


### PR DESCRIPTION
## What

- Return no values from `Values` and `ValuesE` when a `Result` is Invalid.
- Add regression coverage for zero results, invalid selectors, missing fields, and out-of-range indexes across `Get` and `GetE`.

## Why

An invalid result means nothing was resolved, but the accessors exposed a ghost `nil` element as `[nil]`. Callers could mistake that element for a resolved value.

## How

Both value-list accessors short-circuit on `Type()==Invalid` before generic expansion. Results containing typed nil values remain `Interface` and effective, while scalar C4 behavior remains unchanged.

## Tests

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -gcflags=all=-d=checkptr=2 ./... -count=1`
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- independent mutations removing each Invalid guard

Fixes #55
Relates #37
