### PR TITLE
fix: 让 no-op selector 保持空结果状态 (#51)

### DIFF
--- a/issue51_test.go
+++ b/issue51_test.go
@@ -94,6 +94,26 @@ func TestIssue51ResultNoOpPreservesEmptyExpansionState(t *testing.T) {
 	}
 }
 
+func TestIssue51OrdinaryResultNoOpKeepsC1Type(t *testing.T) {
+	resolved := ognl.Get(resultContractUser{Name: "alice"}, "Name")
+	require.Equal(t, ognl.String, resolved.Type())
+
+	for _, selector := range []string{"", ".", "..."} {
+		t.Run(selector, func(t *testing.T) {
+			got := resolved.Get(selector)
+			assert.Equal(t, ognl.Interface, got.Type())
+			assert.True(t, got.Effective())
+			assert.Equal(t, "alice", got.Value())
+
+			gotE, err := resolved.GetE(selector)
+			require.NoError(t, err)
+			assert.Equal(t, ognl.Interface, gotE.Type())
+			assert.True(t, gotE.Effective())
+			assert.Equal(t, "alice", gotE.Value())
+		})
+	}
+}
+
 func TestIssue51RealOperationAfterEmptyExpansionStillFails(t *testing.T) {
 	empty := []struct{ Name string }{}
 	for _, selector := range []string{"#.Name", "#..Name", "##"} {

--- a/issue51_test.go
+++ b/issue51_test.go
@@ -1,0 +1,118 @@
+package ognl_test
+
+import (
+	"testing"
+
+	ognl "github.com/golang-infrastructure/go-ognl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssue51NoOpSelectorKeepsNilInput(t *testing.T) {
+	for _, selector := range []string{"", ".", "..."} {
+		t.Run(selector, func(t *testing.T) {
+			result := ognl.Get(nil, selector)
+			assert.Equal(t, ognl.Interface, result.Type())
+			assert.False(t, result.Effective())
+			assert.Nil(t, result.Value())
+			assert.Empty(t, result.Diagnosis())
+
+			resultE, err := ognl.GetE(nil, selector)
+			require.NoError(t, err)
+			assert.Equal(t, ognl.Interface, resultE.Type())
+			assert.False(t, resultE.Effective())
+			assert.Nil(t, resultE.Value())
+			assert.Empty(t, resultE.Diagnosis())
+		})
+	}
+}
+
+func TestIssue51TrailingSeparatorsKeepEmptyExpansion(t *testing.T) {
+	for _, selector := range []string{"#", "#.", "#.."} {
+		t.Run(selector, func(t *testing.T) {
+			result := ognl.Get([]int{}, selector)
+			assert.Equal(t, ognl.Interface, result.Type())
+			assert.False(t, result.Effective())
+			assert.Nil(t, result.Value())
+			assert.Empty(t, result.Diagnosis())
+
+			resultE, err := ognl.GetE([]int{}, selector)
+			require.NoError(t, err)
+			assert.Equal(t, ognl.Interface, resultE.Type())
+			assert.False(t, resultE.Effective())
+			assert.Nil(t, resultE.Value())
+			assert.Empty(t, resultE.Diagnosis())
+		})
+	}
+}
+
+func TestIssue51ResultNoOpPreservesEmptyExpansionState(t *testing.T) {
+	nilExpanded, err := ognl.GetE([]int{}, "#")
+	require.NoError(t, err)
+
+	nonNilEmpty := ognl.Get([]int{1}, "#.missing")
+	require.NotNil(t, nonNilEmpty.Value())
+	require.Empty(t, nonNilEmpty.Value())
+	require.NotEmpty(t, nonNilEmpty.Diagnosis())
+
+	tests := []struct {
+		name       string
+		result     ognl.Result
+		valueIsNil bool
+	}{
+		{name: "nil empty", result: nilExpanded, valueIsNil: true},
+		{name: "non-nil empty with diagnosis", result: nonNilEmpty, valueIsNil: false},
+	}
+
+	for _, tt := range tests {
+		for _, selector := range []string{"", ".", "..."} {
+			t.Run(tt.name+"/"+selector, func(t *testing.T) {
+				got := tt.result.Get(selector)
+				assert.Equal(t, tt.result.Type(), got.Type())
+				assert.Equal(t, tt.result.Effective(), got.Effective())
+				if tt.valueIsNil {
+					assert.Nil(t, got.Value())
+				} else {
+					assert.NotNil(t, got.Value())
+					assert.Empty(t, got.Value())
+				}
+				assert.Equal(t, tt.result.Diagnosis(), got.Diagnosis())
+
+				gotE, err := tt.result.GetE(selector)
+				require.NoError(t, err)
+				assert.Equal(t, tt.result.Type(), gotE.Type())
+				assert.Equal(t, tt.result.Effective(), gotE.Effective())
+				if tt.valueIsNil {
+					assert.Nil(t, gotE.Value())
+				} else {
+					assert.NotNil(t, gotE.Value())
+					assert.Empty(t, gotE.Value())
+				}
+				assert.Equal(t, tt.result.Diagnosis(), gotE.Diagnosis())
+			})
+		}
+	}
+}
+
+func TestIssue51RealOperationAfterEmptyExpansionStillFails(t *testing.T) {
+	empty := []struct{ Name string }{}
+	for _, selector := range []string{"#.Name", "#..Name", "##"} {
+		t.Run("top-level/"+selector, func(t *testing.T) {
+			result, err := ognl.GetE(empty, selector)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ognl.ErrInvalidValue)
+			assert.False(t, result.Effective())
+		})
+	}
+
+	expanded, err := ognl.GetE(empty, "#")
+	require.NoError(t, err)
+	for _, selector := range []string{"Name", ".Name", "#"} {
+		t.Run("Result/"+selector, func(t *testing.T) {
+			result, err := expanded.GetE(selector)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, ognl.ErrInvalidValue)
+			assert.False(t, result.Effective())
+		})
+	}
+}

--- a/ognl.go
+++ b/ognl.go
@@ -316,6 +316,9 @@ func (r Result) Get(path string) Result {
 		diagnosis = append(diagnosis, wrapResolutionError(err, reflect.TypeOf(r.raw), state.selectorError(path)))
 		return Result{typ: Invalid, diagnosis: diagnosis}
 	}
+	if onlySelectorSeparators(tokens) {
+		return r
+	}
 	return r.get(tokens, path, &expansionBudget{}, state)
 }
 
@@ -374,6 +377,9 @@ func (r Result) GetE(path string) (Result, error) {
 	tokens, err := parseSelector(path)
 	if err != nil {
 		return Result{typ: Invalid, diagnosis: append([]error(nil), r.diagnosis...)}, wrapResolutionError(err, reflect.TypeOf(r.raw), state.selectorError(path))
+	}
+	if onlySelectorSeparators(tokens) {
+		return r, nil
 	}
 	return r.getE(tokens, path, &expansionBudget{}, state)
 }
@@ -450,6 +456,9 @@ func GetE(value interface{}, path string) (Result, error) {
 	if err != nil {
 		return Result{typ: Invalid}, wrapResolutionError(err, reflect.TypeOf(value), state.selectorError(path))
 	}
+	if onlySelectorSeparators(tokens) {
+		tokens = nil
+	}
 	return getE(value, tokens, path, 0, &expansionBudget{}, state)
 }
 
@@ -476,6 +485,12 @@ func getE(value interface{}, tokens []selectorToken, path string, depth int, bud
 	for index, token := range tokens {
 		if token.kind == selectorSeparatorToken {
 			remaining := tokens[index+1:]
+			if onlySelectorSeparators(remaining) {
+				if !result.deployment {
+					result.typ = Interface
+				}
+				continue
+			}
 			location := state.firstOperation(remaining)
 			if result.deployment {
 				list := result.raw.([]interface{})
@@ -673,6 +688,9 @@ func Get(value interface{}, path string) Result {
 	if err != nil {
 		return Result{typ: Invalid, diagnosis: []error{wrapResolutionError(err, reflect.TypeOf(value), state.selectorError(path))}}
 	}
+	if onlySelectorSeparators(tokens) {
+		tokens = nil
+	}
 	return get(value, tokens, path, 0, &expansionBudget{}, state)
 }
 
@@ -702,6 +720,12 @@ func get(value interface{}, tokens []selectorToken, path string, depth int, budg
 	for index, token := range tokens {
 		if token.kind == selectorSeparatorToken {
 			remaining := tokens[index+1:]
+			if onlySelectorSeparators(remaining) {
+				if !result.deployment {
+					result.typ = Interface
+				}
+				continue
+			}
 			location := state.firstOperation(remaining)
 			if result.deployment {
 				list := result.raw.([]interface{})

--- a/ognl.go
+++ b/ognl.go
@@ -316,7 +316,7 @@ func (r Result) Get(path string) Result {
 		diagnosis = append(diagnosis, wrapResolutionError(err, reflect.TypeOf(r.raw), state.selectorError(path)))
 		return Result{typ: Invalid, diagnosis: diagnosis}
 	}
-	if onlySelectorSeparators(tokens) {
+	if raw, ok := r.raw.([]interface{}); r.deployment && ok && len(raw) == 0 && onlySelectorSeparators(tokens) {
 		return r
 	}
 	return r.get(tokens, path, &expansionBudget{}, state)
@@ -378,7 +378,7 @@ func (r Result) GetE(path string) (Result, error) {
 	if err != nil {
 		return Result{typ: Invalid, diagnosis: append([]error(nil), r.diagnosis...)}, wrapResolutionError(err, reflect.TypeOf(r.raw), state.selectorError(path))
 	}
-	if onlySelectorSeparators(tokens) {
+	if raw, ok := r.raw.([]interface{}); r.deployment && ok && len(raw) == 0 && onlySelectorSeparators(tokens) {
 		return r, nil
 	}
 	return r.getE(tokens, path, &expansionBudget{}, state)


### PR DESCRIPTION
## What

- Treat empty and separator-only selectors as no-op for nil inputs and empty expanded Results.
- Keep trailing separators from turning an empty expansion into a failed query.
- Add regressions for nil/non-nil empty expansions, Diagnosis preservation, and existing C1 behavior.

## Why

`GetE(nil, ".")`, `GetE(empty, "#.")`, and `emptyResult.GetE("")` incorrectly returned `ErrInvalidValue`, even though the selectors contain no operation beyond the completed expansion.

## How

Top-level entry points normalize separator-only selectors to the existing empty-path flow. The walkers stop when only trailing separators remain, and Result methods shortcut only empty deployed Results. Ordinary resolved Results continue to use the existing C1 empty-path semantics; Invalid chaining remains unchanged.

## Tests

- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -gcflags=all=-d=checkptr=2 ./... -count=1`
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- independent broad-shortcut and missing-empty-shortcut mutations

Fixes #51
Relates #37
