### PR TITLE
fix: return direct recursive anonymous fields (#57)

### DIFF
--- a/issue57_test.go
+++ b/issue57_test.go
@@ -2,6 +2,7 @@ package ognl_test
 
 import (
 	"testing"
+	"time"
 
 	ognl "github.com/golang-infrastructure/go-ognl"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,14 @@ import (
 type Issue57Node struct {
 	*Issue57Node
 	ID int
+}
+
+type Issue57NamedPointerCycle *Issue57NamedPointerCycle
+
+type Issue57AnonymousValue interface{}
+
+type issue57AnonymousInterfaceHolder struct {
+	Issue57AnonymousValue
 }
 
 func assertIssue57DirectAnonymousField(t *testing.T, value, want *Issue57Node) {
@@ -57,4 +66,34 @@ func TestIssue57RecursiveAnonymousNamePreservesTypedNil(t *testing.T) {
 	require.Equal(t, ognl.Pointer, resultE.Type())
 	assert.True(t, resultE.Effective())
 	assert.Nil(t, resultE.Value())
+}
+
+func TestIssue57AnonymousInterfaceNamedPointerCycleReturns(t *testing.T) {
+	var pointer Issue57NamedPointerCycle
+	value := issue57AnonymousInterfaceHolder{Issue57AnonymousValue: pointer}
+	type outcome struct {
+		result  ognl.Result
+		resultE ognl.Result
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		result := ognl.Get(value, "Issue57AnonymousValue")
+		resultE, err := ognl.GetE(value, "Issue57AnonymousValue")
+		done <- outcome{result: result, resultE: resultE, err: err}
+	}()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		for _, result := range []ognl.Result{got.result, got.resultE} {
+			require.Equal(t, ognl.Interface, result.Type())
+			assert.True(t, result.Effective())
+			actual, ok := result.Value().(Issue57NamedPointerCycle)
+			require.True(t, ok)
+			assert.Nil(t, actual)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("anonymous interface lookup did not return for a named pointer type cycle")
+	}
 }

--- a/issue57_test.go
+++ b/issue57_test.go
@@ -1,6 +1,9 @@
 package ognl_test
 
 import (
+	"context"
+	"os"
+	"os/exec"
 	"testing"
 	"time"
 
@@ -8,6 +11,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const issue57PointerCycleScenario = "GO_OGNL_ISSUE57_POINTER_CYCLE_SCENARIO"
 
 type Issue57Node struct {
 	*Issue57Node
@@ -69,31 +74,34 @@ func TestIssue57RecursiveAnonymousNamePreservesTypedNil(t *testing.T) {
 }
 
 func TestIssue57AnonymousInterfaceNamedPointerCycleReturns(t *testing.T) {
+	if os.Getenv(issue57PointerCycleScenario) != "" {
+		runIssue57AnonymousInterfaceNamedPointerCycle(t)
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestIssue57AnonymousInterfaceNamedPointerCycleReturns$", "-test.count=1")
+	cmd.Env = append(os.Environ(), issue57PointerCycleScenario+"=child")
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() == context.DeadlineExceeded {
+		t.Fatalf("anonymous interface lookup did not return before timeout; child output:\n%s", output)
+	}
+	require.NoError(t, err, "anonymous interface lookup child failed; output:\n%s", output)
+}
+
+func runIssue57AnonymousInterfaceNamedPointerCycle(t *testing.T) {
 	var pointer Issue57NamedPointerCycle
 	value := issue57AnonymousInterfaceHolder{Issue57AnonymousValue: pointer}
-	type outcome struct {
-		result  ognl.Result
-		resultE ognl.Result
-		err     error
-	}
-	done := make(chan outcome, 1)
-	go func() {
-		result := ognl.Get(value, "Issue57AnonymousValue")
-		resultE, err := ognl.GetE(value, "Issue57AnonymousValue")
-		done <- outcome{result: result, resultE: resultE, err: err}
-	}()
-
-	select {
-	case got := <-done:
-		require.NoError(t, got.err)
-		for _, result := range []ognl.Result{got.result, got.resultE} {
-			require.Equal(t, ognl.Interface, result.Type())
-			assert.True(t, result.Effective())
-			actual, ok := result.Value().(Issue57NamedPointerCycle)
-			require.True(t, ok)
-			assert.Nil(t, actual)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("anonymous interface lookup did not return for a named pointer type cycle")
+	result := ognl.Get(value, "Issue57AnonymousValue")
+	resultE, err := ognl.GetE(value, "Issue57AnonymousValue")
+	require.NoError(t, err)
+	for _, result := range []ognl.Result{result, resultE} {
+		require.Equal(t, ognl.Interface, result.Type())
+		assert.True(t, result.Effective())
+		actual, ok := result.Value().(Issue57NamedPointerCycle)
+		require.True(t, ok)
+		assert.Nil(t, actual)
 	}
 }

--- a/issue57_test.go
+++ b/issue57_test.go
@@ -1,0 +1,60 @@
+package ognl_test
+
+import (
+	"testing"
+
+	ognl "github.com/golang-infrastructure/go-ognl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Issue57Node struct {
+	*Issue57Node
+	ID int
+}
+
+func assertIssue57DirectAnonymousField(t *testing.T, value, want *Issue57Node) {
+	t.Helper()
+
+	result := ognl.Get(value, "Issue57Node")
+	require.Equal(t, ognl.Pointer, result.Type())
+	assert.True(t, result.Effective())
+	assert.Same(t, want, result.Value())
+
+	resultE, err := ognl.GetE(value, "Issue57Node")
+	require.NoError(t, err)
+	require.Equal(t, ognl.Pointer, resultE.Type())
+	assert.True(t, resultE.Effective())
+	assert.Same(t, want, resultE.Value())
+}
+
+func TestIssue57RecursiveAnonymousNameReturnsDirectField(t *testing.T) {
+	tail := &Issue57Node{ID: 3}
+	middle := &Issue57Node{Issue57Node: tail, ID: 2}
+	root := &Issue57Node{Issue57Node: middle, ID: 1}
+
+	assertIssue57DirectAnonymousField(t, root, middle)
+	assertIssue57DirectAnonymousField(t, middle, tail)
+}
+
+func TestIssue57RecursiveAnonymousNameReturnsSelfCycle(t *testing.T) {
+	cycle := &Issue57Node{ID: 1}
+	cycle.Issue57Node = cycle
+
+	assertIssue57DirectAnonymousField(t, cycle, cycle)
+}
+
+func TestIssue57RecursiveAnonymousNamePreservesTypedNil(t *testing.T) {
+	value := &Issue57Node{ID: 1}
+
+	result := ognl.Get(value, "Issue57Node")
+	require.Equal(t, ognl.Pointer, result.Type())
+	assert.True(t, result.Effective())
+	assert.Nil(t, result.Value())
+
+	resultE, err := ognl.GetE(value, "Issue57Node")
+	require.NoError(t, err)
+	require.Equal(t, ognl.Pointer, resultE.Type())
+	assert.True(t, resultE.Effective())
+	assert.Nil(t, resultE.Value())
+}

--- a/ognl.go
+++ b/ognl.go
@@ -1198,7 +1198,12 @@ func parseString(t reflect.Type, v reflect.Value, value string, depth int) (inte
 
 		if rt.Anonymous {
 			embeddedType := reflect.TypeOf(res)
+			seenTypes := make(map[reflect.Type]struct{})
 			for embeddedType != nil && embeddedType.Kind() == reflect.Ptr {
+				if _, seen := seenTypes[embeddedType]; seen {
+					break
+				}
+				seenTypes[embeddedType] = struct{}{}
 				embeddedType = embeddedType.Elem()
 			}
 			if embeddedType == t {

--- a/ognl.go
+++ b/ognl.go
@@ -1197,6 +1197,13 @@ func parseString(t reflect.Type, v reflect.Value, value string, depth int) (inte
 		res := reflect.NewAt(rv.Type(), unsafe.Pointer(rv.UnsafeAddr())).Elem().Interface()
 
 		if rt.Anonymous {
+			embeddedType := reflect.TypeOf(res)
+			for embeddedType != nil && embeddedType.Kind() == reflect.Ptr {
+				embeddedType = embeddedType.Elem()
+			}
+			if embeddedType == t {
+				return res, Type(rv.Kind()), t, nil
+			}
 			nv, nt, failureType, ne := parseString(reflect.TypeOf(res), reflect.ValueOf(res), value, depth+1)
 			if ne == nil && nt != Invalid {
 				return nv, nt, failureType, ne


### PR DESCRIPTION
## What

- Return the direct anonymous field when a recursive embedded pointer has the same concrete type as the current struct.
- Terminate named pointer-type cycles while preserving typed-nil values.
- Add identity regressions for finite recursive chains, self-cycles, typed nil endpoints, and `Get`/`GetE` parity.

## Why

Named lookup already located the current struct's direct anonymous field, but legacy promotion recursion continued through same-type recursive values and returned the chain tail. The initial type guard also needed explicit protection against legal named pointer cycles such as `type P *P`.

## How

Before legacy anonymous-field recursion, the code dereferences the embedded value's type with cycle detection and compares it with the current struct type. Same-type recursion returns the direct field; named pointer cycles terminate and fall back safely; non-recursive same-name collisions retain the existing behavior.

## Tests

- targeted issue #57, #31, #26, and self-reference tests
- isolated child-process timeout for named pointer cycles
- `go test ./... -count=1`
- `go test -race ./... -count=1`
- `go test -gcflags=all=-d=checkptr=2 ./... -count=1`
- `go vet ./...`
- `go mod verify`
- `go mod tidy -diff`
- independent same-type, kind-broadening, cycle-guard, and process-isolation mutations

Fixes #57
Relates #37
